### PR TITLE
Add command to create new block at top of buffer

### DIFF
--- a/electron/initial-content.ts
+++ b/electron/initial-content.ts
@@ -6,6 +6,7 @@ const altChar = isMac ? "⌥" : "Alt"
 const keyHelp = [
     [`${modChar} + Enter`, "Add new block below the current block"],
     [`${modChar} + Shift + Enter`, "Split the current block at cursor position"],
+    [`${modChar} + ${altChar} + Enter`, "Add new block at top of buffer"],
     [`${modChar} + L`, "Change block language"],
     [`${modChar} + Down`, "Goto next block"],
     [`${modChar} + Up`, "Goto previous block"],

--- a/src/editor/block/commands.js
+++ b/src/editor/block/commands.js
@@ -47,6 +47,25 @@ export const addNewBlockAfterCurrent = ({ state, dispatch }) => {
     return true;
 }
 
+export const addNewBlockUpTop = ({ state, dispatch }) => {
+    if (state.readOnly)
+        return false
+    const block = state.facet(blockState)[0]
+    const delimText = "\n∞∞∞text-a\n"
+
+    dispatch(state.update({
+        changes: {
+            from: block.content.from,
+            insert: delimText,
+        },
+        selection: EditorSelection.cursor(block.content.from - delimText.length)
+    }, {
+        scrollIntoView: true,
+        userEvent: "input",
+    }))
+    return true;
+}
+
 export function changeLanguageTo(state, dispatch, block, language, auto) {
     if (state.readOnly)
         return false

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -7,6 +7,7 @@ import {
 import { 
     insertNewBlockAtCursor, 
     addNewBlockAfterCurrent, 
+    addNewBlockUpTop,
     moveLineUp, moveLineDown, 
     selectAll, 
     gotoPreviousBlock, gotoNextBlock, 
@@ -40,6 +41,7 @@ export function heynoteKeymap(editor) {
         ["Shift-Tab", indentLess],
         ["Mod-Enter", addNewBlockAfterCurrent],
         ["Mod-Shift-Enter", insertNewBlockAtCursor],
+        ["Mod-Alt-Enter", addNewBlockUpTop],
         ["Mod-a", selectAll],
         ["Alt-ArrowUp", moveLineUp],
         ["Alt-ArrowDown", moveLineDown],


### PR DESCRIPTION
## Praise

Hey this is a really cool tool. I often have to find some arbitrary text editor, and then my files, and then pick some scratch file etc. when I want to jot down notes.

## What's this PR?

Adds a shortcut to create a new block at the top of the buffer, and move the cursor there.

## Why?

When I collect notes I like to put the new things up top, the longer notes linger the less important they usually get, so in my view it's nice if they slowly just flow down out of sight lower in the document. I understand this is a preference and not everyone wants things the same, but I figured I could share my local changes so I gave it a separate shortcut here and opened a PR.

I totally get if the plan is to not add a bunch of features.