### PR TITLE
implement vim keymap (Resolves Issue #24) 

### DIFF
--- a/electron/config.js
+++ b/electron/config.js
@@ -21,7 +21,7 @@ const schema = {
     settings: {
         type: "object",
         properties: {
-            "keymap": { "enum": ["default", "emacs"], default:"default" },
+            "keymap": { "enum": ["default", "emacs", "vim"], default:"default" },
             "emacsMetaKey": { "enum": [null, "alt", "meta"], default: null },
             "showLineNumberGutter": {type: "boolean", default:true},
             "showFoldGutter": {type: "boolean", default:true},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.4.2",
       "license": "Commons Clause MIT",
       "dependencies": {
+        "@replit/codemirror-vim": "^6.1.0",
         "electron-log": "^5.0.1"
       },
       "devDependencies": {
@@ -266,7 +267,6 @@
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.2.tgz",
       "integrity": "sha512-tjoi4MCWDNxgIpoLZ7+tezdS9OEB6pkiDKhfKx9ReJ/XBcs2G2RXIu+/FxXBlWsPTsz6C9q/r4gjzrsxpcnqCQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -440,7 +440,6 @@
       "version": "6.9.3",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.9.3.tgz",
       "integrity": "sha512-qq48pYzoi6ldYWV/52+Z9Ou6QouVI+8YwvxFbUypI33NbjG2UeRHKENRyhwljTTiOqjQ33FjyZj6EREQ9apAOQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -465,7 +464,6 @@
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
       "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -475,14 +473,12 @@
     "node_modules/@codemirror/state": {
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.3.tgz",
-      "integrity": "sha512-0wufKcTw2dEwEaADajjHf6hBy1sh3M6V0e+q4JKIhLuiMSe5td5HOWpUdvKth1fT1M9VYOboajoBHpkCd7PG7A==",
-      "dev": true
+      "integrity": "sha512-0wufKcTw2dEwEaADajjHf6hBy1sh3M6V0e+q4JKIhLuiMSe5td5HOWpUdvKth1fT1M9VYOboajoBHpkCd7PG7A=="
     },
     "node_modules/@codemirror/view": {
       "version": "6.22.2",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.2.tgz",
       "integrity": "sha512-cJp64cPXm7QfSBWEXK+76+hsZCGHupUgy8JAbSzMG6Lr0rfK73c1CaWITVW6hZVkOnAFxJTxd0PIuynNbzxYPw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -981,8 +977,7 @@
     "node_modules/@lezer/common": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.2.tgz",
-      "integrity": "sha512-V+GqBsga5+cQJMfM0GdnHmg4DgWvLzgMWjbldBg0+jC3k9Gu6nJNZDLJxXEBT1Xj8KhRN4jmbC5CY7SIL++sVw==",
-      "dev": true
+      "integrity": "sha512-V+GqBsga5+cQJMfM0GdnHmg4DgWvLzgMWjbldBg0+jC3k9Gu6nJNZDLJxXEBT1Xj8KhRN4jmbC5CY7SIL++sVw=="
     },
     "node_modules/@lezer/cpp": {
       "version": "1.1.1",
@@ -1021,7 +1016,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
       "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
-      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1081,7 +1075,6 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
       "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
-      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1207,6 +1200,18 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@replit/codemirror-vim": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.1.0.tgz",
+      "integrity": "sha512-XATcrMBYphSgTTDHaL5cTdBKA+/kwg8x0kHpX9xFHkI8c2G9+nXdkIzFCtk76x1VDYQSlT6orNhudNt+9H9zOA==",
+      "peerDependencies": {
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.1.0",
+        "@codemirror/search": "^6.2.0",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.0.3"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -2698,8 +2703,7 @@
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5519,8 +5523,7 @@
     "node_modules/style-mod": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
-      "dev": true
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -6304,8 +6307,7 @@
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vue-tsc": "^1.0.16"
   },
   "dependencies": {
+    "@replit/codemirror-vim": "^6.1.0",
     "electron-log": "^5.0.1"
   }
 }

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -15,6 +15,7 @@
                 keymaps: [
                     { name: "Default", value: "default" },
                     { name: "Emacs", value: "emacs" },
+                    { name: "Vim", value: "vim"},
                 ],
                 keymap: this.initialSettings.keymap,
                 metaKey: this.initialSettings.emacsMetaKey,

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -12,6 +12,7 @@ import { noteBlockExtension, blockLineNumbers } from "./block/block.js"
 import { changeCurrentBlockLanguage, triggerCurrenciesLoaded } from "./block/commands.js"
 import { formatBlockContent } from "./block/format-code.js"
 import { heynoteKeymap } from "./keymap.js"
+import { vimKeymap } from "./keymap.js"
 import { emacsKeymap } from "./emacs.js"
 import { heynoteCopyPaste } from "./copy-paste"
 import { languageDetection } from "./language-detection/autodetect.js"
@@ -24,6 +25,8 @@ export const LANGUAGE_SELECTOR_EVENT = "openLanguageSelector"
 function getKeymapExtensions(editor, keymap) {
     if (keymap === "emacs") {
         return emacsKeymap(editor)
+    } else if (keymap === "vim") {
+        return vimKeymap(editor)
     } else {
         return heynoteKeymap(editor)
     }

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -1,4 +1,5 @@
 import { keymap } from "@codemirror/view"
+import { Vim, vim } from "@replit/codemirror-vim"
 //import { EditorSelection, EditorState } from "@codemirror/state"
 import {
     indentLess, indentMore, 
@@ -52,4 +53,13 @@ export function heynoteKeymap(editor) {
         {key:"Ctrl-ArrowUp", run:gotoPreviousParagraph, shift:selectPreviousParagraph},
         {key:"Ctrl-ArrowDown", run:gotoNextParagraph, shift:selectNextParagraph},
     ])
+}
+
+export function vimKeymap(editor) {
+    //Vim.defineEx("DeleteLineFix", (editor) => {
+       //editor.view.cm.execCommand("deleteLine")
+    //})
+
+  //Vim.map("\\\\", ":DeleteLineFix", "normal")
+    return [heynoteKeymap(editor), vim()]
 }


### PR DESCRIPTION
Hey there, I decided to take a stab at #24 and this is what I came up with. 

I used the codemirror-vim package: [repo](https://github.com/replit/codemirror-vim) as suggested by @nilsherzig [here](https://github.com/heyman/heynote/issues/24#issuecomment-1867999861). 

All in all it works without a hitch! cut (dd, dw, d$, etc.), copy (yy, yw, y$, etc.) and paste (p) all work without issue in my testing. Along with this, all the basic movement commands I tested (h, j, k, l, gg, G, w, b), highlighting (Shift-V, Ctrl-v), etc. all worked. 

The only issue I managed to find was if you delete the whole line (dd) inside of an empty or 1 line block it uncovers the separator regex for the next block, and the next block inherits the code highlighting of the block you just removed. I tried to find a workaround for this, but with my limited JavaScript skills and lack of understanding of how the app works as a whole, I could only deduce that it had something to do with maybe the extra line break between the separators getting deleted. [these comments I think help support this hypothesis](https://github.com/heyman/heynote/blob/main/src/editor/block/move-lines.js#L42-L44).

I am unsure if this issue can be avoided without implementing a custom keymap like what you have in emacs.js. The commented out code in keymap.js was my sad attempt at trying to avoid deleting the extra line break. Perhaps someone with more knowledge with codemirror and it's Vim keybindings package can make a better attempt at fixing the issue!

Overall, I think the net positive of having Vim keybindings is worth the minor headache of having to delete the `∞∞∞text` that pops up and reassign the blocks highlighting, but ultimately that's not my call!

PS. Sweet app! I find myself too often pasting things inside of a new tab address bar for temporary jotting. Once I saw your post on Hacker News I knew I had to get it... so long as it had Vim keybindings :wink:    
