### PR TITLE
Fix issue with large buffers where block delimiters wouldn't be "atomic" when first starting Heynote, before the first edit

### DIFF
--- a/src/editor/block/block.js
+++ b/src/editor/block/block.js
@@ -13,9 +13,9 @@ import { emptyBlockSelected } from "./select-all.js";
 // tracks the size of the first delimiter
 let firstBlockDelimiterSize
 
-export function getBlocks(state) {
+export function getBlocks(state, timeout=50) {
     const blocks = [];  
-    const tree = ensureSyntaxTree(state, state.doc.length)
+    const tree = ensureSyntaxTree(state, state.doc.length, timeout)
     if (tree) {
         tree.iterate({
             enter: (type) => {
@@ -57,7 +57,7 @@ export function getBlocks(state) {
 
 export const blockState = StateField.define({
     create(state) {
-        return getBlocks(state);
+        return getBlocks(state, 1000);
     },
     update(blocks, transaction) {
         // if blocks are empty it likely means we didn't get a parsed syntax tree, and then we want to update

--- a/src/editor/block/block.js
+++ b/src/editor/block/block.js
@@ -13,7 +13,7 @@ import { emptyBlockSelected } from "./select-all.js";
 // tracks the size of the first delimiter
 let firstBlockDelimiterSize
 
-export function getBlocks(state, timeout=50) {
+function getBlocks(state, timeout=50) {
     const blocks = [];  
     const tree = ensureSyntaxTree(state, state.doc.length, timeout)
     if (tree) {
@@ -63,10 +63,8 @@ export const blockState = StateField.define({
         // if blocks are empty it likely means we didn't get a parsed syntax tree, and then we want to update
         // the blocks on all updates (and not just document changes)
         if (transaction.docChanged || blocks.length === 0) {
-            //console.log("updating block state", transaction)
             return getBlocks(transaction.state);
         }
-        //return widgets.map(transaction.changes);
         return blocks
     },
 })

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -8,7 +8,7 @@ import { heynoteDark } from "./theme/dark.js"
 import { heynoteBase } from "./theme/base.js"
 import { customSetup } from "./setup.js"
 import { heynoteLang } from "./lang-heynote/heynote.js"
-import { noteBlockExtension, blockLineNumbers, getBlocks } from "./block/block.js"
+import { noteBlockExtension, blockLineNumbers, blockState } from "./block/block.js"
 import { heynoteEvent, SET_CONTENT } from "./annotation.js";
 import { changeCurrentBlockLanguage, triggerCurrenciesLoaded } from "./block/commands.js"
 import { formatBlockContent } from "./block/format-code.js"
@@ -128,7 +128,7 @@ export class HeynoteEditor {
     }
 
     getBlocks() {
-        return getBlocks(this.view.state)
+        return this.view.state.facet(blockState)
     }
 
     focus() {


### PR DESCRIPTION
Increase timeout for parsing the syntax tree when it's done for the first time.

Fixes an issue with large buffers where block delimiters wouldn't be "atomic" (and thus could be corrupted) when first starting the program, before the first edit.