### PR TITLE
Fix: Enable bracket surround

### DIFF
--- a/src/editor/setup.js
+++ b/src/editor/setup.js
@@ -59,7 +59,7 @@ const customSetup = /*@__PURE__*/(() => [
     indentOnInput(),
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
     bracketMatching(),
-    //closeBrackets(),
+    closeBrackets(),
     //autocompletion(),
     rectangularSelection(),
     crosshairCursor(),


### PR DESCRIPTION
Remove the comment from `setup.js` that was preventing the possibility to surround/wrap the selection with brackets, quotes... 

This fixes #13.
