### PR TITLE
Add a default language setting

### DIFF
--- a/electron/config.js
+++ b/electron/config.js
@@ -1,5 +1,36 @@
 import Store from "electron-store"
 
+let sortedLanguages = [
+    "csharp",
+    "cpp",
+    "clojure",
+    "css",
+    "erlang",
+    "golang",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "jsx",
+    "kotlin",
+    "lezer",
+    "markdown",
+    "math",
+    "php",
+    "text",
+    "python",
+    "ruby",
+    "rust",
+    "shell",
+    "sql",
+    "swift",
+    "toml",
+    "tsx",
+    "typescript",
+    "xml",
+    "yaml",
+]
+
 const isDev = !!process.env.VITE_DEV_SERVER_URL
 
 const schema = {
@@ -32,6 +63,7 @@ const schema = {
             "bufferPath" : {type: "string", default: ""},
             "showInDock": {type: "boolean", default: true},
             "showInMenu": {type: "boolean", default: false},
+            "defaultLanguage": { "enum": sortedLanguages, default: "text" },
         },
     },
 
@@ -59,6 +91,7 @@ const defaults = {
         bufferPath: "",
         showInDock: true,
         showInMenu: false,
+        defaultLanguage: "text"
     },
     theme: "system",
 }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -118,6 +118,7 @@
             :keymap="settings.keymap"
             :showLineNumberGutter="settings.showLineNumberGutter"
             :showFoldGutter="settings.showFoldGutter"
+            :defaultLanguage="settings.defaultLanguage"
             class="editor"
             ref="editor"
             @openLanguageSelector="openLanguageSelector"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -19,6 +19,10 @@
                 type: Boolean,
                 default: true,
             },
+            defaultLanguage: {
+                type: String,
+                default: "text",
+            },
         },
 
         components: {},
@@ -61,6 +65,7 @@
                     keymap: this.keymap,
                     showLineNumberGutter: this.showLineNumberGutter,
                     showFoldGutter: this.showFoldGutter,
+                    defaultLanguage: this.defaultLanguage,
                 })
                 window._heynote_editor = this.editor
                 window.document.addEventListener("currenciesLoaded", this.onCurrenciesLoaded)

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -2,6 +2,8 @@
     import KeyboardHotkey from "./KeyboardHotkey.vue"
     import TabListItem from "./TabListItem.vue"
     import TabContent from "./TabContent.vue"
+    import { sortedLanguages } from "@/src/editor/languages";
+    import { setNewBlockLanguage } from "@/src/editor/block/commands";
 
     export default {
         props: {
@@ -30,7 +32,9 @@
                 globalHotkey: this.initialSettings.globalHotkey,
                 showInDock: this.initialSettings.showInDock,
                 showInMenu: this.initialSettings.showInMenu,
+                defaultLanguage: this.initialSettings.defaultLanguage,
                 autoUpdate: this.initialSettings.autoUpdate,
+                languages: sortedLanguages,
 
                 activeTab: "general",
             }
@@ -63,7 +67,9 @@
                     showInDock: this.showInDock,
                     showInMenu: this.showInMenu || !this.showInDock,
                     autoUpdate: this.autoUpdate,
+                    defaultLanguage: this.defaultLanguage,
                 })
+              setNewBlockLanguage(this.defaultLanguage)
             },
         }
     }
@@ -132,6 +138,19 @@
                                     v-model="globalHotkey"
                                     @change="updateSettings"
                                 />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="entry">
+                                <h2>Input settings</h2>
+                                <label>
+                                    Default Language
+                                    <select ref="defaultLanguageSelector" v-model="defaultLanguage" @change="updateSettings">
+                                      <template v-for="lg in languages" :key="lg.token">
+                                        <option :selected="lg.token === defaultLanguage" :value="lg.token">{{ lg.name }}</option>
+                                      </template>
+                                    </select>
+                                </label>
                             </div>
                         </div>
                         <div class="row">

--- a/src/editor/block/commands.js
+++ b/src/editor/block/commands.js
@@ -6,6 +6,12 @@ import { selectAll } from "./select-all.js";
 
 export { moveLineDown, moveLineUp, selectAll }
 
+let newBlockLanguage = window.heynote.settings.defaultLanguage || "text"
+
+export const setNewBlockLanguage = (language) => {
+    newBlockLanguage = language
+}
+
 
 export const insertNewBlockAtCursor = ({ state, dispatch }) => {
     if (state.readOnly)
@@ -16,7 +22,7 @@ export const insertNewBlockAtCursor = ({ state, dispatch }) => {
     if (currentBlock) {
         delimText = `\n∞∞∞${currentBlock.language.name}${currentBlock.language.auto ? "-a" : ""}\n`
     } else {
-        delimText = "\n∞∞∞text-a\n"
+        delimText = `\n∞∞∞${newBlockLanguage}-a\n`
     }
     dispatch(state.replaceSelection(delimText), 
         {
@@ -32,7 +38,7 @@ export const addNewBlockAfterCurrent = ({ state, dispatch }) => {
     if (state.readOnly)
         return false
     const block = getActiveNoteBlock(state)
-    const delimText = "\n∞∞∞text-a\n"
+    const delimText = `\n∞∞∞${newBlockLanguage}-a\n`
 
     dispatch(state.update({
         changes: {

--- a/src/editor/languages.js
+++ b/src/editor/languages.js
@@ -237,6 +237,15 @@ export const LANGUAGES = [
 
 const languageMapping = Object.fromEntries(LANGUAGES.map(l => [l.token, l]))
 
+export const sortedLanguages = LANGUAGES.map(l => {
+    return {
+        "token": l.token,
+        "name": l.name
+    }
+}).sort((a, b) => {
+    return a.name.localeCompare(b.name)
+})
+
 export function getLanguage(token) {
     return languageMapping[token]
 }


### PR DESCRIPTION
This commit introduces the ability to set and use a default programming language for new editor blocks. Key changes include:
- Adding a sorted list of languages and a `defaultLanguage` setting in the configuration.
- Propagating the `defaultLanguage` setting to relevant components and functions.
- Enabling users to select and update the default language in the settings UI.

This fixes #61 