### PR TITLE
Hide Heynote from taskbar when Tray icon has been turned on in Windows

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -63,6 +63,12 @@ if (isBetaVersion) {
     CONFIG.set("settings.allowBetaVersions", true)
 }
 
+let forceQuit = false
+export function quit() {
+    forceQuit = true
+    app.quit()
+}
+
 
 async function createWindow() {
     // read any stored window settings from config, or use defaults
@@ -87,7 +93,7 @@ async function createWindow() {
             nodeIntegration: true,
             contextIsolation: true,
         },
-
+        skipTaskbar: isWindows && CONFIG.get("settings.showInMenu"),
     }, windowConfig))
 
     // maximize window if it was maximized last time
@@ -99,6 +105,11 @@ async function createWindow() {
     }
 
     win.on("close", (event) => {
+        if (!forceQuit && isWindows && CONFIG.get("settings.showInMenu")) {
+            event.preventDefault()
+            win.hide()
+            return
+        }
         // Prevent the window from closing, and send a message to the renderer which will in turn
         // send a message to the main process to save the current buffer and close the window.
         if (!contentSaved) {
@@ -206,6 +217,9 @@ function registerShowInMenu() {
         createTray()
     } else {
         tray?.destroy()
+    }
+    if (isWindows) {
+        win.setSkipTaskbar(CONFIG.get("settings.showInMenu"))
     }
 }
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -105,7 +105,7 @@ async function createWindow() {
     }
 
     win.on("close", (event) => {
-        if (!forceQuit && isWindows && CONFIG.get("settings.showInMenu")) {
+        if (!forceQuit && CONFIG.get("settings.showInMenu")) {
             event.preventDefault()
             win.hide()
             return

--- a/electron/main/menu.ts
+++ b/electron/main/menu.ts
@@ -1,6 +1,7 @@
 const { app, Menu } = require("electron")
 import { OPEN_SETTINGS_EVENT } from "../constants";
 import { openAboutWindow } from "./about";
+import { quit } from "./index"
 
 const isMac = process.platform === "darwin"
 
@@ -157,7 +158,7 @@ export function getTrayMenu(win) {
         {
             label: 'Quit',
             click: () => {
-                app.quit()
+                quit()
             },
         },
     ])

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -180,7 +180,12 @@
                                         v-model="showInMenu"
                                         @change="updateSettings"
                                     />
-                                    Show system tray
+                                    <template v-if="isMac">
+                                        Show in menu bar
+                                    </template>
+                                    <template v-else>
+                                        Show in system tray
+                                    </template>
                                 </label>
                             </div>
                         </div>

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -70,6 +70,9 @@
                     bracketClosing: this.bracketClosing,
                     bufferPath: this.bufferPath,
                 })
+                if (!this.showInDock) {
+                    this.showInMenu = true
+                }
             },
 
             async selectBufferLocation() {


### PR DESCRIPTION
Hide Heynote from taskbar on Windows when Tray icon has been turned on. Make close button just hide the window, and require using the Tray menu to quit for real. Fixes #137.