### PR TITLE
Explicitly document that Math blocks use math.js expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Alt                    Show menu
 
 ### Can Math blocks do X?
 
-Heynote's Math blocks are powered by [Math.js expressions](https://mathjs.org/docs/expressions). Checkout their [documentation](https://mathjs.org/docs/reference/index.html) to see what [functions](https://mathjs.org/docs/reference/functions.html) and [constants](https://mathjs.org/docs/reference/constants.html) are available.
+Heynote's Math blocks are powered by [Math.js expressions](https://mathjs.org/docs/expressions). Checkout their [documentation](https://mathjs.org/docs/) to see what [syntax](https://mathjs.org/docs/expressions/syntax.html), [functions](https://mathjs.org/docs/reference/functions.html), and [constants](https://mathjs.org/docs/reference/constants.html) are available.
 
 
 ## Thanks!

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Alt                    Show menu
 
 ### Can Math blocks do X?
 
-Heynote's Math blocks are powered by [Math.js](https://mathjs.org/). Checkout their [documentation](https://mathjs.org/docs/reference/index.html) to see what [functions](https://mathjs.org/docs/reference/functions.html) and [constants](https://mathjs.org/docs/reference/constants.html) are available.
+Heynote's Math blocks are powered by [Math.js expressions](https://mathjs.org/docs/expressions). Checkout their [documentation](https://mathjs.org/docs/reference/index.html) to see what [functions](https://mathjs.org/docs/reference/functions.html) and [constants](https://mathjs.org/docs/reference/constants.html) are available.
 
 
 ## Thanks!


### PR DESCRIPTION
Until I started digging around on the math.js website and found the concept of "expressions", I didn't fully understand how math.js was being used in this app. Was the text in math blocks being evaluated as Javascript somehow?

With this PR, the README directly mentions and links to the documentation about math.js expressions, which is a much better starting place for learning how to properly use Math blocks. This is especially important because expressions have some critical differences from Javascript, such as using 1-indexed matrices.