### PR TITLE
Update initial-content.ts

### DIFF
--- a/electron/initial-content.ts
+++ b/electron/initial-content.ts
@@ -12,7 +12,7 @@ ${keyHelpStr(os.platform())}
 This is a Math block. Here, rows are evaluated as math expressions. 
 
 radius = 5
-volume = radius^2 * PI
+area = radius^2 * PI
 sqrt(9)
 
 It also supports some basic unit conversions, including currencies:


### PR DESCRIPTION
Fixed typo in initial content

## Why
The area of a circle is pi times the radius squared (A = π r²), not the volume.