### PR TITLE
Add prev variable to Math blocks that holds the previous value

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ To run the tests in the Playwright UI:
 
 I'm happy to merge contributions that fit my vision for the app. Bug fixes are always welcome. 
 
+## Math Blocks
+
+Heynote's Math blocks are powered by [Math.js expressions](https://mathjs.org/docs/expressions). Checkout their [documentation](https://mathjs.org/docs/) to see what [syntax](https://mathjs.org/docs/expressions/syntax.html), [functions](https://mathjs.org/docs/reference/functions.html), and [constants](https://mathjs.org/docs/reference/constants.html) are available.
+
+### Accessing the previous result
+
+The variable `prev` can be used to access the previous result. For example:
+
+```
+128
+prev * 2 # 256
+```
+
+### Changing how the results of Math blocks are formatted?
+
+You can define a custom `format` function within the Math block like this:
+
+```
+_format = format # store reference to the built in format
+format(x) = _format(x, {notation:"exponential"})
+```
+
+See the [Math.js format()](https://mathjs.org/docs/reference/functions/format.html) function for more info on what's supported.
+
+
 ## FAQ
 
 ### Where is the buffer data stored?
@@ -126,22 +151,6 @@ Ctrl + Alt + Up/Down   Add additional cursor above/below
 Alt + Shift + F        Format block content (works for JSON, JavaScript, HTML, CSS and Markdown)
 Alt                    Show menu
 ```
-
-### Can Math blocks do X?
-
-Heynote's Math blocks are powered by [Math.js expressions](https://mathjs.org/docs/expressions). Checkout their [documentation](https://mathjs.org/docs/) to see what [syntax](https://mathjs.org/docs/expressions/syntax.html), [functions](https://mathjs.org/docs/reference/functions.html), and [constants](https://mathjs.org/docs/reference/constants.html) are available.
-
-## Can I change how the results of Math blocks are formatted?
-
-Yes! You can define a custom `format` function within the Math block like this:
-
-```
-_format = format # store reference to the built in format
-format(x) = _format(x, {notation:"exponential"})
-```
-
-See the [Math.js format()](https://mathjs.org/docs/reference/functions/format.html) function for more info on what's supported.
-
 
 ## Thanks!
 

--- a/src/editor/block/math.js
+++ b/src/editor/block/math.js
@@ -51,16 +51,20 @@ function mathDeco(view) {
 
             if (block && block.language.name == "math") {
                 // get math.js parser and cache it for this block
-                let parser = mathParsers.get(block)
+                let {parser, prev} = mathParsers.get(block) || {}
                 if (!parser) {
                     parser = window.math.parser()
-                    mathParsers.set(block, parser)
+                    mathParsers.set(block, {parser, prev})
                 }
                 
                 // evaluate math line
                 let result
                 try {
+                    parser.set("prev", prev)
                     result = parser.evaluate(line.text)
+                    if (result !== undefined) {
+                        mathParsers.set(block, {parser, prev:result})
+                    }
                 } catch (e) {
                     // suppress any errors
                 }

--- a/tests/math.spec.js
+++ b/tests/math.spec.js
@@ -33,3 +33,26 @@ format(x) = _format(x, {notation:"exponential"})
 `)
     await expect(page.locator("css=.heynote-math-result").last()).toHaveText("4.2e+1")
 })
+
+test("previous result in prev variable", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞math
+128
+prev * 2 # 256
+`)
+    await expect(page.locator("css=.heynote-math-result").last()).toHaveText("256")
+})
+
+test("previous result in prev variable", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞math
+1336
+23 /
+# comment
+test
+prev+1#comment
+prev
+`)
+    await expect(page.locator("css=.heynote-math-result").last()).toHaveText("1337")
+})
+

--- a/tests/math.spec.js
+++ b/tests/math.spec.js
@@ -43,7 +43,7 @@ prev * 2 # 256
     await expect(page.locator("css=.heynote-math-result").last()).toHaveText("256")
 })
 
-test("previous result in prev variable", async ({ page }) => {
+test("previous result in prev variable rows with invalid values", async ({ page }) => {
     await heynotePage.setContent(`
 ∞∞∞math
 1336


### PR DESCRIPTION
Moved documentation on Math blocks from the FAQ into it's own section in the Readme.