### PR TITLE
Remove unneeded macOS signing entitlements

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -4,8 +4,6 @@
 	<dict>
 		<key>com.apple.security.cs.allow-jit</key>
 		<true/>
-		<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-		<true/>
 		<key>com.apple.security.inherit</key>
 		<true/>
 		<key>com.apple.security.network.client</key>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -4,9 +4,5 @@
 	<dict>
 		<key>com.apple.security.cs.allow-jit</key>
 		<true/>
-		<key>com.apple.security.inherit</key>
-		<true/>
-		<key>com.apple.security.network.client</key>
-    	<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
Hiyo, thanks again for the app. After installing Heynote on my Mac I noticed the entitlements were slightly off. Hopefully they should be good now :)

- `com.apple.security.cs.allow-dyld-environment-variables`: This isn't needed and just pokes holes in the hardened runtime. All it lets you do is inject dynamic libraries and mess with the process environment externally. 

The other ones I removed only do anything when your app is sandboxed, and Heynote is not since its using the standard Electron build. If you ever distribute Heynote on [the Mac app store](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide#enable-apples-app-sandbox), you'll need to [bring these back](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide#network-access) in another file, 

- `com.apple.security.inherit`: Usually makes sure child processes get the same sandbox as the main parent, but not used here since the main process does this without help from the system (like Chromium itself)
- `com.apple.security.network.client`: Lets a sandboxed app make outbound network connections. Again the main Heynote process isn't sandboxed so it can already make whatever connections desired.