### PR TITLE
Add Homebrew Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Available for Mac, Windows, and Linux.
 
 Download the appropriate (Mac, Windows or Linux) version from the latest Github release (or from [heynote.com](https://heynote.com)). The Windows build is not signed, so you might see some scary warning (I can not justify paying a yearly fee for a certificate just to get rid of that).
 
+Alternativly, macOS users can utilise [Homebrew](https://formulae.brew.sh/cask/heynote#default): `brew install --cask heynote`
+
 ### Notes on Linux installation
 
 It's been reported [(#48)](https://github.com/heyman/heynote/issues/48) that ChromeOS's Debian VM need the following packages installed to run the Heynote AppImage:


### PR DESCRIPTION
Added Homebrew installation instructions for macOS users, including a link to the Homebrew cask page and subsequent shell command.