### PR TITLE
Add default redo cmd that works on all Platforms. Mod+Shift+Z

### DIFF
--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -1,7 +1,7 @@
 import { keymap } from "@codemirror/view"
 //import { EditorSelection, EditorState } from "@codemirror/state"
 import {
-    indentLess, indentMore, 
+    indentLess, indentMore, redo,
 } from "@codemirror/commands"
 
 import { 
@@ -61,6 +61,7 @@ export function heynoteKeymap(editor) {
         ["Mod-Alt-ArrowDown", newCursorBelow],
         ["Mod-Alt-ArrowUp", newCursorAbove],
         ["Mod-Shift-k", deleteLine],
+        ["Mod-Shift-z", redo],
         {key:"Mod-ArrowUp", run:gotoPreviousBlock, shift:selectPreviousBlock},
         {key:"Mod-ArrowDown", run:gotoNextBlock, shift:selectNextBlock},
         {key:"Ctrl-ArrowUp", run:gotoPreviousParagraph, shift:selectPreviousParagraph},


### PR DESCRIPTION
I solved the Issue https://github.com/heyman/heynote/issues/212 for a universal Redo shortcut CMD/Control + Shift + Z across Windows, Linux, and Mac.

I tested it on Ubuntu 24.04, Mac OS 15.0, and Windows 11 23H2 works as intended.
Windows now has Control + Y and Control + Shift + Z 