### PR TITLE
Fix icon for nix systems

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -114,9 +114,17 @@ async function createWindow() {
         }
     }
 
+    const pngSystems: NodeJS.Platform[] = ["linux", "freebsd", "openbsd", "netbsd"]
+    const icon = join(
+        process.env.PUBLIC,
+        pngSystems.includes(process.platform)
+            ? "favicon-linux.png"
+            : "favicon.ico",
+    )
+
     win = new BrowserWindow(Object.assign({
         title: 'heynote',
-        icon: join(process.env.PUBLIC, 'favicon.ico'),
+        icon,
         backgroundColor: nativeTheme.shouldUseDarkColors ? '#262B37' : '#FFFFFF',
         //titleBarStyle: 'customButtonsOnHover',
         autoHideMenuBar: true,


### PR DESCRIPTION
Linux and BSD variants prefer `.png` files over `.ico` files. And will revert to the desktop environment default icon (in my case X icon)

Looking at the docs, the best way is to use NativeIcon is a better way to manage. For speed this change uses the string path still

### Before

![image](https://github.com/user-attachments/assets/0da44848-8296-44fd-af13-273b189123d5)

### After

![image](https://github.com/user-attachments/assets/2feaa873-4edf-4af5-b679-6b4d2a391c83)
