### PR TITLE
Highlight code in PHP blocks also when <?php tags are missing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ Here are the most notable changes in each release. For a more detailed list of c
 - Added support for the following languages:
   * Elixir
   * Scala
+- PHP blocks no longer requires `<?php` for syntax highlighting to work
 
 
 ## 2.0.0

--- a/src/editor/languages.js
+++ b/src/editor/languages.js
@@ -120,7 +120,7 @@ export const LANGUAGES = [
     new Language({
         token: "php",
         name: "PHP",
-        parser: phpLanguage.parser,
+        parser: phpLanguage.configure({top:"Program"}).parser,
         guesslang: "php",
     }),
     new Language({


### PR DESCRIPTION
Fixes #210 