### PR TITLE
Position the cursor at the beginning of the next block when a block is deleted

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Here are the most notable changes in each release. For a more detailed list of c
 ## 2.1.0 (not yet released)
 
 - Added support for moving the current block to another (or new) buffer. Pressing `Ctrl/Cmd+S` will now pop up a dialog where you can search for and select another buffer to which the block will be moved. It's also possible to select to create a brand new buffer to which the block will be moved.
+- When deleting a block, the cursor will now end up at the beginning of the next block, instead of at the end of the previous block.
 - Added support for the following languages:
   * Elixir
   * Scala

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -238,6 +238,13 @@ export class HeynoteEditor {
         return this.view.state.selection.main.head
     }
 
+    setCursorPosition(position) {
+        this.view.dispatch({
+            selection: {anchor: position, head: position},
+            scrollIntoView: true,
+        })
+    }
+
     focus() {
         this.view.focus()
     }

--- a/tests/delete-block.spec.js
+++ b/tests/delete-block.spec.js
@@ -1,0 +1,44 @@
+import {expect, test} from "@playwright/test";
+import {HeynotePage} from "./test-utils.js";
+
+import { AUTO_SAVE_INTERVAL } from "../src/common/constants.js"
+import { NoteFormat } from "../src/common/note-format.js"
+
+
+let heynotePage
+
+test.beforeEach(async ({page}) => {
+    heynotePage = new HeynotePage(page)
+    await heynotePage.goto()
+
+    expect((await heynotePage.getBlocks()).length).toBe(1)
+    await heynotePage.setContent(`
+∞∞∞text
+Block A
+∞∞∞markdown
+Block B
+∞∞∞text
+Block C`)
+    await page.waitForTimeout(100)
+})
+
+test("delete first block", async ({page}) => {
+    await heynotePage.setCursorPosition(10)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+Shift+D"))
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(13)
+})
+
+test("delete middle block", async ({page}) => {
+    await heynotePage.setCursorPosition(32)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+Shift+D"))
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(25)
+})
+
+test("delete last block", async ({page}) => {
+    await heynotePage.setCursorPosition(52)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+Shift+D"))
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(36)
+})

--- a/tests/move-block.spec.js
+++ b/tests/move-block.spec.js
@@ -25,15 +25,17 @@ Block C`)
 
     // check that visual block layers are created
     await expect(page.locator("css=.heynote-blocks-layer > div")).toHaveCount(3)
-});
 
-
-test("move block to other buffer", async ({page}) => {
+    // create secondary buffer
     await heynotePage.saveBuffer("other.txt", `
 ∞∞∞text-a
 First block
 ∞∞∞math
 Second block`)
+});
+
+
+test("move block to other buffer", async ({page}) => {
     await page.locator("body").press(heynotePage.agnosticKey("Mod+S"))
     await page.waitForTimeout(50)
     await page.locator("body").press("Enter")
@@ -62,11 +64,6 @@ Block C`)
 
 
 test("move block to other open/cached buffer", async ({page}) => {
-    await heynotePage.saveBuffer("other.txt", `
-∞∞∞text-a
-First block
-∞∞∞math
-Second block`)
     await page.locator("body").press(heynotePage.agnosticKey("Mod+P"))
     await page.locator("body").press("Enter")
     await page.waitForTimeout(50)
@@ -99,3 +96,30 @@ Block C`)
 
 })
 
+test("cursor position after moving first block", async ({page}) => {
+    await heynotePage.setCursorPosition(10)
+    expect(await heynotePage.getCursorPosition()).toBe(10)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+S"))
+    await page.waitForTimeout(50)
+    await page.locator("body").press("Enter")
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(9)
+})
+
+test("cursor position after moving middle block", async ({page}) => {
+    await heynotePage.setCursorPosition(28)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+S"))
+    await page.waitForTimeout(50)
+    await page.locator("body").press("Enter")
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(25)
+})
+
+test("cursor position after moving last block", async ({page}) => {
+    await heynotePage.setCursorPosition(48)
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+S"))
+    await page.waitForTimeout(50)
+    await page.locator("body").press("Enter")
+    await page.waitForTimeout(50)
+    expect(await heynotePage.getCursorPosition()).toBe(32)
+})

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -48,6 +48,10 @@ export class HeynotePage {
         return await this.page.evaluate(() => window._heynote_editor.getCursorPosition())
     }
 
+    async setCursorPosition(position) {
+        await this.page.evaluate((position) => window._heynote_editor.setCursorPosition(position), position)
+    }
+
     async getBlockContent(blockIndex) {
         const blocks = await this.getBlocks()
         const content = await this.getContent()


### PR DESCRIPTION
This also changes the behavior when blocks are moved. 

To me it makes more sense that the cursors ends up in the next block instead of the previous. This also has the added benefit that it's now possible to move multiple consecutive blocks to another buffer by pressing `Ctrl/Cmd-S Enter` multiple times and have them end up in the same order in the other buffer.