### PR TITLE
Fix escaping issue in buffer selector

### DIFF
--- a/src/components/BufferSelector.vue
+++ b/src/components/BufferSelector.vue
@@ -263,8 +263,8 @@
                         @click="selectItem(item)"
                         ref="item"
                     >
-                        <span class="name" v-html="item.name" />
-                        <span class="path" v-html="item.folder" />
+                        <span class="name">{{ item.name }}</span>
+                        <span class="path">{{ item.folder }}</span>
                         <span :class="{'action-buttons':true, 'visible':actionButton > 0 && idx === selected}">
                             <button 
                                 v-if="actionButton > 0 && idx === selected"


### PR DESCRIPTION
Buffer names and paths are now properly escaped.

Fixes #308 