### PR TITLE
Fix issue when pressing Ctrl/Cmd+A in non-editor text inputs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Here are the most notable changes in each release. For a more detailed list of c
 ## 2.1.4 (not released yet)
 
 - Fix issue with positioning and size of todo list checkboxes in Markdown blocks when using a non-default font size, or a non-monospaced font.
+- Fix issue when pressing `Ctrl/Cmd+A` in a text input inside a modal dialog (e.g. the buffer selector). Previously the select all command would be sent to the editor.
 
 ## 2.1.3
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -85,11 +85,14 @@
                 "showCreateBuffer",
                 "showEditBuffer",
                 "showMoveToBufferSelector",
-                "openMoveToBufferSelector",
             ]),
 
+            dialogVisible() {
+                return this.showLanguageSelector || this.showBufferSelector || this.showCreateBuffer || this.showEditBuffer || this.showMoveToBufferSelector
+            },
+
             editorInert() {
-                return this.showCreateBuffer || this.showSettings || this.showEditBuffer
+                return this.dialogVisible
             },
         },
 

--- a/src/components/BufferSelector.vue
+++ b/src/components/BufferSelector.vue
@@ -133,6 +133,12 @@
                     return
                 }
 
+                // support Ctrl/Cmd+A to select all
+                if (event.key === "a" && event[window.heynote.platform.isMac ? "metaKey" : "ctrlKey"]) {
+                    event.preventDefault()
+                    event.srcElement.select()
+                }
+
                 if (this.filteredItems.length === 0) {
                     return
                 }

--- a/src/components/EditBuffer.vue
+++ b/src/components/EditBuffer.vue
@@ -120,6 +120,12 @@
             },
 
             onInputKeydown(event) {
+                // support Ctrl/Cmd+A to select all
+                if (event.key === "a" && event[window.heynote.platform.isMac ? "metaKey" : "ctrlKey"]) {
+                    event.preventDefault()
+                    event.srcElement.select()
+                }
+                
                 // redirect arrow keys and page up/down to folder selector
                 const redirectKeys = ["ArrowDown", "ArrowUp", "PageDown", "PageUp"]
                 if (redirectKeys.includes(event.key)) {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -22,6 +22,10 @@
                 syntaxTreeDebugContent: null,
                 editor: null,
                 onWindowClose: null,
+                onUndo: null,
+                onRedo: null,
+                onDeleteBlock: null,
+                onSelectAll: null,
             }
         },
 
@@ -39,29 +43,36 @@
             }
             window.heynote.mainProcess.on(WINDOW_CLOSE_EVENT, this.onWindowClose)
 
-            window.heynote.mainProcess.on(UNDO_EVENT, () => {
+            this.onUndo = () => {
                 if (this.editor) {
                     toRaw(this.editor).undo()
                 }
-            })
+            }
+            window.heynote.mainProcess.on(UNDO_EVENT, this.onUndo)
 
-            window.heynote.mainProcess.on(REDO_EVENT, () => {
+            this.onRedo = () => {
                 if (this.editor) {
                     toRaw(this.editor).redo()
                 }
-            })
+            }
+            window.heynote.mainProcess.on(REDO_EVENT, this.onRedo)
             
-            window.heynote.mainProcess.on(DELETE_BLOCK_EVENT, () => {
+            this.onDeleteBlock = () => {
                 if (this.editor) {
                     toRaw(this.editor).deleteActiveBlock()
                 }
-            })
+            }
+            window.heynote.mainProcess.on(DELETE_BLOCK_EVENT, this.onDeleteBlock)
 
-            window.heynote.mainProcess.on(SELECT_ALL_EVENT, () => {
+            this.onSelectAll = () => {
                 if (this.editor) {
-                    toRaw(this.editor).selectAll()
+                    // make sure the editor is focused
+                    if (this.$refs.editor.contains(document.activeElement)) {
+                        toRaw(this.editor).selectAll()
+                    }
                 }
-            })
+            }
+            window.heynote.mainProcess.on(SELECT_ALL_EVENT, this.onSelectAll)
 
             // if debugSyntaxTree prop is set, display syntax tree for debugging
             if (this.debugSyntaxTree) {
@@ -85,10 +96,10 @@
 
         beforeUnmount() {
             window.heynote.mainProcess.off(WINDOW_CLOSE_EVENT, this.onWindowClose)
-            window.heynote.mainProcess.off(UNDO_EVENT)
-            window.heynote.mainProcess.off(REDO_EVENT)
-            window.heynote.mainProcess.off(DELETE_BLOCK_EVENT)
-            window.heynote.mainProcess.off(SELECT_ALL_EVENT)
+            window.heynote.mainProcess.off(UNDO_EVENT, this.onUndo)
+            window.heynote.mainProcess.off(REDO_EVENT, this.onRedo)
+            window.heynote.mainProcess.off(DELETE_BLOCK_EVENT, this.onDeleteBlock)
+            window.heynote.mainProcess.off(SELECT_ALL_EVENT, this.onSelectAll)
             this.editorCacheStore.tearDown();
         },
 

--- a/src/components/LanguageSelector.vue
+++ b/src/components/LanguageSelector.vue
@@ -50,6 +50,12 @@
 
         methods: {
             onKeydown(event) {
+                // support Ctrl/Cmd+A to select all
+                if (event.key === "a" && event[window.heynote.platform.isMac ? "metaKey" : "ctrlKey"]) {
+                    event.preventDefault()
+                    event.srcElement.select()
+                }
+
                 if (event.key === "ArrowDown") {
                     this.selected = Math.min(this.selected + 1, this.filteredItems.length - 1)
                     event.preventDefault()

--- a/src/components/NewBuffer.vue
+++ b/src/components/NewBuffer.vue
@@ -128,6 +128,12 @@
             },
 
             onInputKeydown(event) {
+                // support Ctrl/Cmd+A to select all
+                if (event.key === "a" && event[window.heynote.platform.isMac ? "metaKey" : "ctrlKey"]) {
+                    event.preventDefault()
+                    event.srcElement.select()
+                }
+                
                 // redirect arrow keys and page up/down to folder selector
                 const redirectKeys = ["ArrowDown", "ArrowUp", "PageDown", "PageUp"]
                 if (redirectKeys.includes(event.key)) {

--- a/src/stores/editor-cache.js
+++ b/src/stores/editor-cache.js
@@ -164,6 +164,9 @@ export const useEditorCacheStore = defineStore("editorCache", {
             }
 
             window.document.removeEventListener("currenciesLoaded", this.onCurrenciesLoaded)
+
+            this.editorCache.lru = []
+            this.editorCache.cache = {}
         },
 
         moveCurrentBlockToOtherEditor(targetPath) {


### PR DESCRIPTION
Previously the Select All command would get sent to the editor even if the editor wasn't in focus