### PR TITLE
Improve folding of blocks and code

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,9 @@ Here are the most notable changes in each release. For a more detailed list of c
 - Fixed an issue where some types of blocks could not be folded. 
 - The fold state is now stored in the buffer file so that it's persisted between sessions. 
 - Added three new commands for folding and unfolding blocks:
-  - `foldBlock` - Folds the current/selected block(s). Default key binding is `Ctrl-Shift-[` on Windows/Linux and `Cmd-Option-[` on Mac.
-  - `unfoldBlock` - Unfolds the current/selected block(s). Default key binding is `Ctrl-Shift-]` on Windows/Linux and `Cmd-Option-]` on Mac.
-  - `toggleFoldBlock` - Toggles the fold state of the current/selected block. Default key binding is `Ctrl-Shift-.` on Windows/Linux and `Cmd-Option-.` on Mac.
+  - `foldBlock` - Folds the current/selected block(s). Default key binding is `Ctrl-Alt-[` on Windows/Linux and `Cmd-Option-[` on Mac.
+  - `unfoldBlock` - Unfolds the current/selected block(s). Default key binding is `Ctrl-Alt-]` on Windows/Linux and `Cmd-Option-]` on Mac.
+  - `toggleFoldBlock` - Toggles the fold state of the current/selected block. Default key binding is `Ctrl-Alt-.` on Windows/Linux and `Cmd-Option-.` on Mac.
 - Folded blocks now display the first 50 characters of the block content, as well as the number of lines in the block.
 
 ## 2.2.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,18 @@
 
 Here are the most notable changes in each release. For a more detailed list of changes, see the [Github Releases page](https://github.com/heyman/heynote/releases).
 
+## 2.3.0-beta (not released yet)
+
+### Improved support for folding blocks
+
+- Fixed an issue where some types of blocks could not be folded. 
+- The fold state is now stored in the buffer file so that it's persisted between sessions. 
+- Added three new commands for folding and unfolding blocks:
+  - `foldBlock` - Folds the current/selected block(s). Default key binding is `Ctrl-Shift-[` on Windows/Linux and `Cmd-Option-[` on Mac.
+  - `unfoldBlock` - Unfolds the current/selected block(s). Default key binding is `Ctrl-Shift-]` on Windows/Linux and `Cmd-Option-]` on Mac.
+  - `toggleFoldBlock` - Toggles the fold state of the current/selected block. Default key binding is `Ctrl-Shift-.` on Windows/Linux and `Cmd-Option-.` on Mac.
+- Folded blocks now display the first 50 characters of the block content, as well as the number of lines in the block.
+
 ## 2.2.2
 
 - Fix issue when changing settings after having upgraded to Heynote 2.2 from an earlier version

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,9 @@ Available for Mac, Windows, and Linux.
 ⌘ + A               Select all text in a note block. Press again to select the whole buffer
 ⌘ + ⌥ + Up/Down     Add additional cursor above/below
 ⌥ + Shift + F       Format block content (works for JSON, JavaScript, HTML, CSS and Markdown)
+⌘ + ⌥ + [           Fold block(s)
+⌘ + ⌥ + ]           Unfold block(s)
+⌘ + ⌥ + .           Toggle block fold
 ```
 
 **On Windows and Linux**
@@ -65,7 +68,13 @@ Ctrl + Up              Goto previous block
 Ctrl + A               Select all text in a note block. Press again to select the whole buffer
 Ctrl + Alt + Up/Down   Add additional cursor above/below
 Alt + Shift + F        Format block content (works for JSON, JavaScript, HTML, CSS and Markdown)
+Ctrl + Shift + [       Fold block(s)
+Ctrl + Shift + ]       Unfold block(s)
+Ctrl + Shift + .       Toggle block fold
 Alt                    Show menu
+
+You can see all the default key bindings in Heynote's settings under Key Bindings.
+
 ```
 
 ## Custom Key Bindings

--- a/shared-utils/key-helper.ts
+++ b/shared-utils/key-helper.ts
@@ -1,4 +1,4 @@
-export const keyHelpStr = (platform: string) => {
+export const keyHelpStr = (platform: string, extended: boolean = false) => {
     const modChar = platform === "darwin" ? "⌘" : "Ctrl"
     const altChar = platform === "darwin" ? "⌥" : "Alt"
 
@@ -18,6 +18,22 @@ export const keyHelpStr = (platform: string) => {
         [`${modChar} + ${altChar} + Up/Down`, "Add additional cursor above/below"],
         [`${altChar} + Shift + F`, "Format block content (works for JSON, JavaScript, HTML, CSS and Markdown)"],
     ]
+
+    if (extended) {
+        if (platform === "darwin") {
+            keyHelp.push(
+                [`${modChar} + ${altChar} + [`, "Fold block(s)"],
+                [`${modChar} + ${altChar} + ]`, "Unfold block(s)"],
+                [`${modChar} + ${altChar} + .`, "Toggle block fold"],
+            )
+        } else {
+            keyHelp.push(
+                [`${modChar} + Shift + [`, "Fold block(s)"],
+                [`${modChar} + Shift + ]`, "Unfold block(s)"],
+                [`${modChar} + Shift + .`, "Toggle block fold"],
+            )
+        }
+    }
 
     if (platform === "win32" || platform === "linux") {
         keyHelp.push([altChar, "Show menu"])

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -20,3 +20,5 @@ export const UPDATE_DOWNLOAD_PROGRESS = "update-download-progress"
 export const UPDATE_START_DOWNLOAD = "auto-update:startDownload"
 export const UPDATE_INSTALL_AND_RESTART = "auto-update:installAndRestart"
 export const UPDATE_CHECK_FOR_UPDATES = "auto-update:checkForUpdates"
+
+export const FOLD_LABEL_LENGTH = 50

--- a/src/common/note-format.js
+++ b/src/common/note-format.js
@@ -42,4 +42,11 @@ export class NoteFormat {
     get cursors() {
         return this.metadata.cursors
     }
+
+    set foldedRanges(foldState) {
+        this.metadata.foldedRanges = foldState
+    }
+    get foldedRanges() {
+        return this.metadata?.foldedRanges || []
+    }
 }

--- a/src/editor/annotation.js
+++ b/src/editor/annotation.js
@@ -16,3 +16,7 @@ export const SET_FONT = "heynote-set-font"
 export function transactionsHasAnnotation(transactions, annotation) {
     return transactions.some(tr => tr.annotation(heynoteEvent) === annotation)
 }
+
+export function transactionsHasHistoryEvent(transactions) {
+    return transactions.some(tr => tr.isUserEvent("undo") || tr.isUserEvent("redo"))
+}

--- a/src/editor/block/block.js
+++ b/src/editor/block/block.js
@@ -265,7 +265,13 @@ export const blockLineNumbers = lineNumbers({
             }
         }
         return ""
-    }
+    },
+    domEventHandlers: {
+        click(view, line, event) {
+            // editor should not loose focus when clicking on the line numbers
+            view.docView.dom.focus()
+        },
+    },
 })
 
 

--- a/src/editor/block/block.js
+++ b/src/editor/block/block.js
@@ -55,6 +55,22 @@ export function getNoteBlockFromPos(state, pos) {
     return state.facet(blockState).find(block => block.range.from <= pos && block.range.to >= pos)
 }
 
+export function getNoteBlocksBetween(state, from, to) {
+    return state.facet(blockState).filter(block => block.range.from < to && block.range.to >= from)
+}
+
+export function getNoteBlocksFromRangeSet(state, ranges) {
+    const blocks = []
+    const seenBlockStarts = new Set()
+    for (const range of ranges) {
+        if (!seenBlockStarts.has(range.from)) {
+            blocks.push(...getNoteBlocksBetween(state, range.from, range.to))
+            seenBlockStarts.add(range.from)
+        }
+    }
+    return blocks
+}
+
 
 class NoteBlockStart extends WidgetType {
     constructor(isFirst) {

--- a/src/editor/block/commands.js
+++ b/src/editor/block/commands.js
@@ -66,7 +66,8 @@ export const addNewBlockAfterCurrent = (editor) => ({ state, dispatch }) => {
             from: block.content.to,
             insert: delimText,
         },
-        selection: EditorSelection.cursor(block.content.to + delimText.length)
+        selection: EditorSelection.cursor(block.content.to + delimText.length),
+        annotations: [heynoteEvent.of(ADD_NEW_BLOCK)],
     }, {
         scrollIntoView: true,
         userEvent: "input",
@@ -106,7 +107,8 @@ export const addNewBlockAfterLast = (editor) => ({ state, dispatch }) => {
             from: block.content.to,
             insert: delimText,
         },
-        selection: EditorSelection.cursor(block.content.to + delimText.length)
+        selection: EditorSelection.cursor(block.content.to + delimText.length),
+        annotations: [heynoteEvent.of(ADD_NEW_BLOCK)],
     }, {
         scrollIntoView: true,
         userEvent: "input",

--- a/src/editor/commands.js
+++ b/src/editor/commands.js
@@ -11,7 +11,7 @@ import {
     insertNewlineAndIndent,
     toggleComment, toggleBlockComment, toggleLineComment,
 } from "@codemirror/commands"
-import { foldCode, unfoldCode } from "@codemirror/language"
+import { foldCode, unfoldCode, toggleFold } from "@codemirror/language"
 import { selectNextOccurrence } from "@codemirror/search"
 import { insertNewlineContinueMarkup } from "@codemirror/lang-markdown"
 
@@ -33,6 +33,7 @@ import { cutCommand, copyCommand, pasteCommand } from "./copy-paste.js"
 
 import { markModeMoveCommand, toggleSelectionMarkMode, selectionMarkModeCancel } from "./mark-mode.js"
 import { insertDateAndTime } from "./date-time.js"
+import { foldBlock, unfoldBlock, toggleBlockFold } from "./fold-gutter.js"
 
 
 const cursorPreviousBlock = markModeMoveCommand(gotoPreviousBlock, selectPreviousBlock)
@@ -101,6 +102,9 @@ const HEYNOTE_COMMANDS = {
     openCreateNewBuffer: cmd(openCreateNewBuffer, "Buffer", "Create new buffer…"),
     cut: cmd(cutCommand, "Clipboard", "Cut selection"),
     copy: cmd(copyCommand, "Clipboard", "Copy selection"),
+    foldBlock: cmd(foldBlock, "Block", "Fold block"),
+    unfoldBlock: cmd(unfoldBlock, "Block", "Unfold block"),
+    toggleBlockFold: cmd(toggleBlockFold, "Block", "Toggle block fold"),
 
     // commands without editor context
     paste: cmdLessContext(pasteCommand, "Clipboard", "Paste from clipboard"),
@@ -127,6 +131,7 @@ const HEYNOTE_COMMANDS = {
     indentLess: cmdLessContext(indentLess, "Edit", "Indent less"),
     foldCode: cmdLessContext(foldCode, "Edit", "Fold code"),
     unfoldCode: cmdLessContext(unfoldCode, "Edit", "Unfold code"),
+    toggleFold: cmdLessContext(toggleFold, "Edit", "Toggle fold"),
     selectNextOccurrence: cmdLessContext(selectNextOccurrence, "Cursor", "Select next occurrence"),
     deleteCharBackward: cmdLessContext(deleteCharBackward, "Edit", "Delete character backward"),
     deleteCharForward: cmdLessContext(deleteCharForward, "Edit", "Delete character forward"),

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -1,6 +1,6 @@
 import { Annotation, EditorState, Compartment, Facet, EditorSelection, Transaction, Prec } from "@codemirror/state"
 import { EditorView, keymap as cmKeymap, drawSelection, ViewPlugin, lineNumbers } from "@codemirror/view"
-import { foldGutter, ensureSyntaxTree } from "@codemirror/language"
+import { ensureSyntaxTree } from "@codemirror/language"
 import { markdown, markdownKeymap } from "@codemirror/lang-markdown"
 import { undo, redo } from "@codemirror/commands"
 
@@ -27,6 +27,7 @@ import { NoteFormat } from "../common/note-format.js"
 import { AUTO_SAVE_INTERVAL } from "../common/constants.js"
 import { useHeynoteStore } from "../stores/heynote-store.js";
 import { useErrorStore } from "../stores/error-store.js";
+import { foldGutterExtension } from "./fold-gutter.js"
 
 
 // Turn off the use of EditContext, since Chrome has a bug (https://issues.chromium.org/issues/351029417) 
@@ -85,7 +86,7 @@ export class HeynoteEditor {
                 //minimalSetup,
                 this.lineNumberCompartment.of(showLineNumberGutter ? blockLineNumbers : []),
                 customSetup, 
-                this.foldGutterCompartment.of(showFoldGutter ? [foldGutter()] : []),
+                this.foldGutterCompartment.of(showFoldGutter ? [foldGutterExtension()] : []),
                 this.closeBracketsCompartment.of(bracketClosing ? [getCloseBracketsExtensions()] : []),
 
                 this.readOnlyCompartment.of([]),
@@ -375,7 +376,7 @@ export class HeynoteEditor {
 
     setFoldGutter(show) {
         this.view.dispatch({
-            effects: this.foldGutterCompartment.reconfigure(show ? [foldGutter()] : []),
+            effects: this.foldGutterCompartment.reconfigure(show ? foldGutterExtension : []),
         })
     }
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -178,7 +178,6 @@ export class HeynoteEditor {
         //console.log("loading content", this.path)
         const content = await window.heynote.buffer.load(this.path)
         this.diskContent = content
-        this.contentLoaded = true
 
         // set up content change listener
         this.onChange = (content) => {
@@ -188,6 +187,7 @@ export class HeynoteEditor {
         window.heynote.buffer.addOnChangeCallback(this.path, this.onChange)
 
         await this.setContent(content)
+        this.contentLoaded = true
     }
 
     setContent(content) {

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -83,7 +83,7 @@ export class HeynoteEditor {
                 heynoteCopyCut(this),
 
                 //minimalSetup,
-                this.lineNumberCompartment.of(showLineNumberGutter ? [lineNumbers(), blockLineNumbers] : []),
+                this.lineNumberCompartment.of(showLineNumberGutter ? blockLineNumbers : []),
                 customSetup, 
                 this.foldGutterCompartment.of(showFoldGutter ? [foldGutter()] : []),
                 this.closeBracketsCompartment.of(bracketClosing ? [getCloseBracketsExtensions()] : []),
@@ -369,7 +369,7 @@ export class HeynoteEditor {
 
     setLineNumberGutter(show) {
         this.view.dispatch({
-            effects: this.lineNumberCompartment.reconfigure(show ? [lineNumbers(), blockLineNumbers] : []),
+            effects: this.lineNumberCompartment.reconfigure(show ? blockLineNumbers : []),
         })
     }
 

--- a/src/editor/fold-gutter.js
+++ b/src/editor/fold-gutter.js
@@ -1,0 +1,169 @@
+import { codeFolding, foldGutter, foldState, unfoldEffect, foldEffect } from "@codemirror/language"
+import { EditorView } from "@codemirror/view"
+import { RangeSet } from "@codemirror/state"
+
+import { FOLD_LABEL_LENGTH } from "@/src/common/constants.js"
+import { getNoteBlockFromPos } from "./block/block.js"
+
+
+// This extension fixes so that a folded region is automatically unfolded if any changes happen 
+// on either the start line or the end line of the folded region (even if the change is not within the folded region)
+const autoUnfoldOnEdit = () => {
+    return EditorView.updateListener.of((update) => {
+        if (!update.docChanged){
+            return
+        }
+
+        const { state, view } = update;
+        const foldRanges = state.field(foldState, false);
+
+        if (!foldRanges || foldRanges.size === 0) {
+            return
+        }
+
+        const unfoldRanges = []
+
+        update.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
+            foldRanges.between(0, state.doc.length, (from, to) => {
+                const lineFrom = state.doc.lineAt(from).from
+                const lineTo = state.doc.lineAt(to).to;
+
+                if ((fromA >= lineFrom && fromA <= lineTo) || (toA >= lineFrom && toA <= lineTo)) {
+                    unfoldRanges.push({ from, to });
+                }
+            });
+        });
+
+        //console.log("Unfold ranges:", unfoldRanges);
+        if (unfoldRanges.length > 0) {
+            view.dispatch({
+                effects: unfoldRanges.map(range => unfoldEffect.of(range)),
+            });
+        }
+    })
+}
+
+export function foldGutterExtension() {
+    return [
+        foldGutter({
+            domEventHandlers: {
+                click(view, line, event) {
+                    // editor should not loose focus when clicking on the fold gutter
+                    view.docView.dom.focus()
+                },
+            },
+        }),
+        codeFolding(
+            {
+                //placeholderText: "⯈ Folded",
+                preparePlaceholder: (state, {from, to}) => {
+                    // Count the number of lines in the folded range
+                    const firstLine = state.doc.lineAt(from)
+                    const lineFrom = firstLine.number
+                    const lineTo = state.doc.lineAt(to).number
+                    const lineCount = lineTo - lineFrom + 1
+
+                    const label = firstLine.text
+                    //console.log("label", label, "line", firstLine)
+                    const labelDom = document.createElement("span")
+                    labelDom.textContent = label.slice(0, 100)
+
+                    const linesDom = document.createElement("span")
+                    linesDom.textContent = `${label.slice(-1).trim() === "" ? '' : ' '}… (${lineCount} lines)`
+                    linesDom.style.fontStyle = "italic"
+                
+                    const dom = document.createElement("span")
+                    dom.className = "cm-foldPlaceholder"
+                    dom.style.opacity = "0.6"
+                    if (firstLine.from === from) {
+                        dom.appendChild(labelDom)
+                    }
+                    dom.appendChild(linesDom)
+                    return dom
+                },
+                placeholderDOM: (view, onClick, prepared) => {
+                    prepared.addEventListener("click", onClick)
+                    return prepared
+                }
+            }
+        ),
+        autoUnfoldOnEdit(),
+    ]
+}
+
+
+export const toggleBlockFold = (editor) => (view) => {
+    const state = view.state
+    const folds = state.field(foldState, false) || RangeSet.empty
+    const effects = []
+
+    state.selection.ranges.map(range => range.head).forEach((pos) => {
+        const block = getNoteBlockFromPos(state, pos)
+        const firstLine = state.doc.lineAt(block.content.from)
+        const blockFolds = []
+        folds.between(block.content.from, block.content.to, (from, to) => {
+            if (from <= firstLine.to && to === block.content.to) {
+                blockFolds.push({from, to})
+            }
+        })
+        if (blockFolds.length > 0) {
+            for (const range of blockFolds) {
+                // If there are folds in the block, unfold them
+                effects.push(unfoldEffect.of(range))
+            }
+        } else {
+            // If there are no folds in the block, fold it
+            const line = state.doc.lineAt(block.content.from)
+            effects.push(foldEffect.of({from: Math.min(line.to, block.content.from + FOLD_LABEL_LENGTH), to: block.content.to}))
+        }
+    })
+
+    if (effects.length > 0) {
+        view.dispatch({
+            effects: effects,
+        })
+    }
+}
+
+
+export const foldBlock = (editor) => (view) => {
+    const state = view.state    
+    const blockRanges = []
+    state.selection.ranges.map(range => range.head).forEach((pos) => {
+        const block = getNoteBlockFromPos(state, pos)
+        if (block) {
+            const line = state.doc.lineAt(block.content.from)
+            blockRanges.push({from: Math.min(line.to, block.content.from + FOLD_LABEL_LENGTH), to: block.content.to})
+        }
+    })
+    const uniqueBlockRanges = [...new Set(blockRanges.map(JSON.stringify))].map(JSON.parse);
+
+    if (uniqueBlockRanges.length > 0) {
+        view.dispatch({
+            effects: uniqueBlockRanges.map(range => foldEffect.of(range)),
+        })
+    }
+}
+
+export const unfoldBlock = (editor) => (view) => {
+    const state = view.state
+    const folds = state.field(foldState, false) || RangeSet.empty
+    const blockFolds = []
+
+    state.selection.ranges.map(range => range.head).forEach((pos) => {
+        const block = getNoteBlockFromPos(state, pos)
+        const firstLine = state.doc.lineAt(block.content.from)
+        folds.between(block.content.from, block.content.to, (from, to) => {
+            //console.log("Fold in block", from, to, "block", block.content.from, block.content.to, firstLine.to)
+            if (from <= firstLine.to && to === block.content.to) {
+                blockFolds.push({from, to})
+            }
+        })
+    })
+
+    if (blockFolds.length > 0) {
+        view.dispatch({
+            effects: blockFolds.map(range => unfoldEffect.of(range)),
+        })
+    }
+}

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -89,6 +89,17 @@ export const DEFAULT_KEYMAP = [
 
     cmd("Mod-/", "toggleComment"),
     cmd("Alt-Shift-a", "toggleBlockComment"),
+    
+    // fold blocks
+    ...(isMac ? [
+        cmd("Alt-Mod-[", "foldBlock"),
+        cmd("Alt-Mod-]", "unfoldBlock"),
+        cmd("Alt-Mod-.", "toggleBlockFold")
+    ] : [
+        cmd("Ctrl-Shift-[", "foldBlock"),
+        cmd("Ctrl-Shift-]", "unfoldBlock"),
+        cmd("Ctrl-Shift-.", "toggleBlockFold")
+    ]),
 
     // search
     //cmd("Mod-f", "openSearchPanel"),

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -62,8 +62,8 @@ export const DEFAULT_KEYMAP = [
     cmd("Mod-Alt-ArrowUp", "newCursorAbove"),
     cmd("Mod-Shift-d", "deleteBlock"),
     cmd("Mod-d", "selectNextOccurrence"),
-    cmd(isMac ? "Cmd-Alt-[" : "Ctrl-Shift-[", "foldCode"),
-    cmd(isMac ? "Cmd-Alt-]" : "Ctrl-Shift-]", "unfoldCode"),
+    cmd(isMac ? "Cmd-Shift-[" : "Ctrl-Shift-[", "foldCode"),
+    cmd(isMac ? "Cmd-Shift-]" : "Ctrl-Shift-]", "unfoldCode"),
 
     cmd("Mod-c", "copy"),
     cmd("Mod-v", "paste"),
@@ -96,9 +96,9 @@ export const DEFAULT_KEYMAP = [
         cmd("Alt-Mod-]", "unfoldBlock"),
         cmd("Alt-Mod-.", "toggleBlockFold")
     ] : [
-        cmd("Ctrl-Shift-[", "foldBlock"),
-        cmd("Ctrl-Shift-]", "unfoldBlock"),
-        cmd("Ctrl-Shift-.", "toggleBlockFold")
+        cmd("Alt-Ctrl-[", "foldBlock"),
+        cmd("Alt-Ctrl-]", "unfoldBlock"),
+        cmd("Alt-Ctrl-.", "toggleBlockFold")
     ]),
 
     // search

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -92,9 +92,9 @@ export const DEFAULT_KEYMAP = [
     
     // fold blocks
     ...(isMac ? [
-        cmd("Alt-Mod-[", "foldBlock"),
-        cmd("Alt-Mod-]", "unfoldBlock"),
-        cmd("Alt-Mod-.", "toggleBlockFold")
+        cmd("Alt-Cmd-[", "foldBlock"),
+        cmd("Alt-Cmd-]", "unfoldBlock"),
+        cmd("Alt-Cmd-.", "toggleBlockFold")
     ] : [
         cmd("Alt-Ctrl-[", "foldBlock"),
         cmd("Alt-Ctrl-]", "unfoldBlock"),

--- a/src/editor/lang-heynote/heynote.js
+++ b/src/editor/lang-heynote/heynote.js
@@ -26,7 +26,7 @@ export const HeynoteLanguage = LRLanguage.define({
                 //NoteContent: foldNode,
                 //NoteContent: foldInside,
                 NoteContent(node) {
-                    return {from:node.from, to:node.to-1}
+                    return {from:node.from, to:node.to}
                 },
             }),
         ],

--- a/src/editor/lang-heynote/heynote.js
+++ b/src/editor/lang-heynote/heynote.js
@@ -7,6 +7,8 @@ import {styleTags, tags as t} from "@lezer/highlight"
 import { json } from "@codemirror/lang-json"
 import { javascript } from "@codemirror/lang-javascript"
 
+import { FOLD_LABEL_LENGTH } from "@/src/common/constants.js"
+
 
 function foldNode(node) {
     //console.log("foldNode", node);
@@ -25,8 +27,9 @@ export const HeynoteLanguage = LRLanguage.define({
             foldNodeProp.add({
                 //NoteContent: foldNode,
                 //NoteContent: foldInside,
-                NoteContent(node) {
-                    return {from:node.from, to:node.to}
+                NoteContent(node, state) {
+                    //return {from:node.from, to:node.to}
+                    return {from: Math.min(state.doc.lineAt(node.from).to, node.from + FOLD_LABEL_LENGTH), to: node.to}
                 },
             }),
         ],

--- a/src/editor/lang-heynote/nested-parser.js
+++ b/src/editor/lang-heynote/nested-parser.js
@@ -34,6 +34,7 @@ export function configureNesting() {
                 //console.log("found parser for language:", langName)
                 return {
                     parser:languageMapping[langName],
+                    overlay: [{from:node.from, to:node.to}],
                 }
             }
         }

--- a/src/editor/theme/base.js
+++ b/src/editor/theme/base.js
@@ -65,11 +65,14 @@ export const heynoteBase = EditorView.theme({
     '.cm-foldGutter': {
         marginLeft: '0px',
     },
-    '.cm-foldGutter .cm-gutterElement': {
-        opacity: 0,
-        transition: "opacity 400ms",
+    '.cm-gutters .cm-gutterElement span': {
+        opacity: 1,
+        transition: "opacity 200ms",
     },
-    '.cm-gutters:hover .cm-gutterElement': {
+    '.cm-foldGutter .cm-gutterElement span[title*="Fold"]': {
+        opacity: 0,
+    },
+    '.cm-gutters:hover .cm-gutterElement span[title*="Fold"]': {
         opacity: 1,
     },
     '.cm-cursor, .cm-dropCursor': {

--- a/tests/folding.spec.js
+++ b/tests/folding.spec.js
@@ -65,4 +65,20 @@ This is a markdown block
         const content = await heynotePage.getContent()
         expect(content).toContain("abc test")
     });
+
+    test("block can be folded", async ({ page }) => {
+        // Position cursor in first block (which has multiple lines)
+        await heynotePage.setCursorPosition(20) // Middle of Block A
+        
+        // Verify no fold placeholder exists initially
+        await expect(page.locator(".cm-foldPlaceholder")).not.toBeVisible()
+        
+        // Fold block using keyboard shortcut
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Ctrl+Shift+["
+        await page.locator("body").press(foldKey)
+        await page.waitForTimeout(100)
+        
+        // Verify block is folded by checking for fold placeholder
+        await expect(page.locator(".cm-foldPlaceholder")).toBeVisible()
+    });
 });

--- a/tests/folding.spec.js
+++ b/tests/folding.spec.js
@@ -72,7 +72,7 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).not.toBeVisible()
         
         // Fold block using keyboard shortcut
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Control+["
         await page.locator("body").press(foldKey)
         
         // Verify block is folded by checking for fold placeholder
@@ -88,7 +88,7 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
         
         // Fold multiple blocks using keyboard shortcut
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Control+["
         await page.locator("body").press(foldKey)
         
         // Verify multiple blocks are folded (should see multiple fold placeholders)
@@ -96,7 +96,7 @@ This is a markdown block
         await expect(foldPlaceholders).toHaveCount(3) // Block A, B, and D should be folded (C is single line so won't fold)
         
         // Unfold all blocks using keyboard shortcut
-        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Ctrl+]"
+        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Control+]"
         await page.locator("body").press(unfoldKey)
         
         // Verify all blocks are unfolded (no fold placeholders should remain)
@@ -111,7 +111,7 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
         
         // Toggle fold to fold the block
-        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Control+."
         await page.locator("body").press(toggleKey)
         
         // Verify block is folded
@@ -133,7 +133,7 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
         
         // Toggle fold to fold multiple blocks
-        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Control+."
         await page.locator("body").press(toggleKey)
         
         // Verify multiple blocks are folded
@@ -150,7 +150,7 @@ This is a markdown block
     test("toggleBlockFold with mixed folded/unfolded state", async ({ page }) => {
         // Fold Block A first
         await heynotePage.setCursorPosition(20) // Middle of Block A
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Control+["
         await page.locator("body").press(foldKey)
         
         // Verify Block A is folded
@@ -161,7 +161,7 @@ This is a markdown block
         await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Second press selects entire buffer
         
         // Toggle fold on mixed state - should fold all unfolded blocks (since more are unfolded than folded)
-        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Control+."
         await page.locator("body").press(toggleKey)
         
         // Verify all foldable blocks are now folded (A was already folded, B and D should now be folded too)
@@ -177,7 +177,7 @@ This is a markdown block
     test("folded blocks are stored in buffer metadata", async ({ page }) => {
         // Fold Block A (multi-line block)
         await heynotePage.setCursorPosition(20) // Middle of Block A
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Control+["
         await page.locator("body").press(foldKey)
         
         // Verify block is folded
@@ -215,7 +215,7 @@ This is a markdown block
         expect(updatedNote.foldedRanges.length).toBe(2)
         
         // Unfold all blocks
-        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Ctrl+]"
+        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Control+]"
         await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Select all
         await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Select entire buffer
         await page.locator("body").press(unfoldKey)
@@ -234,7 +234,7 @@ This is a markdown block
     test("folded blocks persist across page reloads", async ({ page }) => {
         // Fold Block A (multi-line block)
         await heynotePage.setCursorPosition(20) // Middle of Block A
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Control+["
         await page.locator("body").press(foldKey)
         
         // Verify block is folded
@@ -259,7 +259,7 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(1)
         
         // Now unfold the block
-        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Ctrl+]"
+        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Control+]"
         await page.locator("body").press(unfoldKey)
         
         // Verify block is unfolded

--- a/tests/folding.spec.js
+++ b/tests/folding.spec.js
@@ -21,8 +21,7 @@ console.log("Block B")
 let x = 42
 return x * 2
 ∞∞∞text
-Block C
-Single line block
+Block C single line
 ∞∞∞markdown
 # Block D
 This is a markdown block
@@ -39,7 +38,6 @@ This is a markdown block
         
         // Click on fold gutter to fold the block
         await page.locator(".cm-foldGutter").first().click()
-        await page.waitForTimeout(100)
         
         // Type a character - this should work if editor maintained focus
         await page.locator("body").pressSequentially("xyz yay")
@@ -56,7 +54,6 @@ This is a markdown block
         
         // Click on line number gutter
         await page.locator(".cm-lineNumbers .cm-gutterElement:visible").first().click()
-        await page.waitForTimeout(100)
         
         // Type a character - this should work if editor maintained focus
         await page.locator("body").pressSequentially("abc test")
@@ -74,11 +71,105 @@ This is a markdown block
         await expect(page.locator(".cm-foldPlaceholder")).not.toBeVisible()
         
         // Fold block using keyboard shortcut
-        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Ctrl+Shift+["
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
         await page.locator("body").press(foldKey)
-        await page.waitForTimeout(100)
         
         // Verify block is folded by checking for fold placeholder
         await expect(page.locator(".cm-foldPlaceholder")).toBeVisible()
+    });
+
+    test("multiple blocks can be folded and unfolded when selection overlaps multiple blocks", async ({ page }) => {
+        // Use Ctrl/Cmd+A twice to select all content across all blocks
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // First press selects current block
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Second press selects entire buffer
+        
+        // Verify no fold placeholders exist initially
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+        
+        // Fold multiple blocks using keyboard shortcut
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        await page.locator("body").press(foldKey)
+        
+        // Verify multiple blocks are folded (should see multiple fold placeholders)
+        const foldPlaceholders = page.locator(".cm-foldPlaceholder")
+        await expect(foldPlaceholders).toHaveCount(3) // Block A, B, and D should be folded (C is single line so won't fold)
+        
+        // Unfold all blocks using keyboard shortcut
+        const unfoldKey = heynotePage.isMac ? "Alt+Meta+]" : "Alt+Ctrl+]"
+        await page.locator("body").press(unfoldKey)
+        
+        // Verify all blocks are unfolded (no fold placeholders should remain)
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+    });
+
+    test("toggleBlockFold works on single block", async ({ page }) => {
+        // Position cursor in first block (which has multiple lines)
+        await heynotePage.setCursorPosition(20) // Middle of Block A
+        
+        // Verify no fold placeholder exists initially
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+        
+        // Toggle fold to fold the block
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        await page.locator("body").press(toggleKey)
+        
+        // Verify block is folded
+        await expect(page.locator(".cm-foldPlaceholder")).toBeVisible()
+        
+        // Toggle fold again to unfold the block
+        await page.locator("body").press(toggleKey)
+        
+        // Verify block is unfolded
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+    });
+
+    test("toggleBlockFold works on multiple blocks", async ({ page }) => {
+        // Select all content across all blocks
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // First press selects current block
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Second press selects entire buffer
+        
+        // Verify no fold placeholders exist initially
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+        
+        // Toggle fold to fold multiple blocks
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        await page.locator("body").press(toggleKey)
+        
+        // Verify multiple blocks are folded
+        const foldPlaceholders = page.locator(".cm-foldPlaceholder")
+        await expect(foldPlaceholders).toHaveCount(3) // Block A, B, and D should be folded (C is single line)
+        
+        // Toggle fold again to unfold all blocks
+        await page.locator("body").press(toggleKey)
+        
+        // Verify all blocks are unfolded
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
+    });
+
+    test("toggleBlockFold with mixed folded/unfolded state", async ({ page }) => {
+        // Fold Block A first
+        await heynotePage.setCursorPosition(20) // Middle of Block A
+        const foldKey = heynotePage.isMac ? "Alt+Meta+[" : "Alt+Ctrl+["
+        await page.locator("body").press(foldKey)
+        
+        // Verify Block A is folded
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(1)
+        
+        // Now select all blocks (some folded, some unfolded)
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // First press selects current block
+        await page.locator("body").press(heynotePage.agnosticKey("Mod+a")) // Second press selects entire buffer
+        
+        // Toggle fold on mixed state - should fold all unfolded blocks (since more are unfolded than folded)
+        const toggleKey = heynotePage.isMac ? "Alt+Meta+." : "Alt+Ctrl+."
+        await page.locator("body").press(toggleKey)
+        
+        // Verify all foldable blocks are now folded (A was already folded, B and D should now be folded too)
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(3) // Block A, B, and D
+        
+        // Toggle fold again - should unfold all blocks
+        await page.locator("body").press(toggleKey)
+        
+        // Verify all blocks are now unfolded
+        await expect(page.locator(".cm-foldPlaceholder")).toHaveCount(0)
     });
 });

--- a/tests/folding.spec.js
+++ b/tests/folding.spec.js
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { HeynotePage } from "./test-utils.js";
+
+let heynotePage
+
+test.beforeEach(async ({ page }) => {
+    heynotePage = new HeynotePage(page)
+    await heynotePage.goto()
+});
+
+test.describe("Block Folding", () => {
+    test.beforeEach(async ({ page }) => {
+        // Set up test content with multiple blocks
+        await heynotePage.setContent(`
+∞∞∞text
+Block A
+Line 2 of Block A
+Line 3 of Block A
+∞∞∞javascript
+console.log("Block B")
+let x = 42
+return x * 2
+∞∞∞text
+Block C
+Single line block
+∞∞∞markdown
+# Block D
+This is a markdown block
+- Item 1
+- Item 2
+`)
+        //await page.waitForTimeout(100);
+        expect((await heynotePage.getBlocks()).length).toBe(4)
+    });
+
+    test("fold gutter doesn't lose editor focus when clicked", async ({ page }) => {
+        // Position cursor in first block
+        await heynotePage.setCursorPosition(20) // Middle of Block A
+        
+        // Click on fold gutter to fold the block
+        await page.locator(".cm-foldGutter").first().click()
+        await page.waitForTimeout(100)
+        
+        // Type a character - this should work if editor maintained focus
+        await page.locator("body").pressSequentially("xyz yay")
+        //await page.waitForTimeout(100)
+        
+        // Verify the character was added to the buffer
+        const content = await heynotePage.getContent()
+        expect(content).toContain("xyz yay")
+    });
+
+    test("line number gutter doesn't lose editor focus when clicked", async ({ page }) => {
+        // Position cursor in first block
+        await heynotePage.setCursorPosition(20) // Middle of Block A
+        
+        // Click on line number gutter
+        await page.locator(".cm-lineNumbers .cm-gutterElement:visible").first().click()
+        await page.waitForTimeout(100)
+        
+        // Type a character - this should work if editor maintained focus
+        await page.locator("body").pressSequentially("abc test")
+        
+        // Verify the character was added to the buffer
+        const content = await heynotePage.getContent()
+        expect(content).toContain("abc test")
+    });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -22,13 +22,16 @@ const injectKeybindsInDocs = async () => {
 	const shortcuts = `$1**On Mac**
 
 \`\`\`
-${keyHelpStr('darwin')}
+${keyHelpStr('darwin', true)}
 \`\`\`
 
 **On Windows and Linux**
 
 \`\`\`
-${keyHelpStr('win32')}
+${keyHelpStr('win32', true)}
+
+You can see all the default key bindings in Heynote's settings under Key Bindings.
+
 $2`
 	const docsPath = path.resolve(__dirname, 'docs', 'index.md')
 	let docs = fs.readFileSync(docsPath, 'utf-8')


### PR DESCRIPTION
This PR improves the functionality of folding and unfolding blocks

* Fix issue where some blocks (depending on language mode) could not be folded/unfolded
* Add commands for folding/unfolding/toggling blocks and assign them default key bindings
* Add toggleFold command (toggles the nearest foldable range)
* Prevent editor from loosing focus when the gutter is clicked
* Fix so that a folded region is automatically unfolded if any changes happen on either the start line or the end line of the folded region (even if the change is not within the folded region)
* Display the number of folded lines for a folded region

This PR should fix: #333, #198, #54