### PR TITLE
Remove CodeMirror markdown extension

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 Here are the most notable changes in each release. For a more detailed list of changes, see the [Github Releases page](https://github.com/heyman/heynote/releases).
 
-## 2.4.0-beta.2
+## 2.4.0-beta.3
 
 ### Improved  search functionality
 
@@ -11,6 +11,7 @@ The new search (and replace) dialog has an improved UI and is now "block aware",
 ### Other fixes and improvements
 
 - Fix issues with todo lists checkboxes in Markdown blocks
+- Fix issue with markdown blocks sometimes not being fully folded
 
 ## 2.3.3
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -117,7 +117,8 @@ export class HeynoteEditor {
                 // Markdown extensions, we need to add markdownKeymap manually with the highest precedence
                 // so that it takes precedence over the default keymap
                 todoCheckboxPlugin,
-                markdown({addKeymap: false}),
+                // don't use the markdown extension, because it messes up the block folding
+                //markdown({addKeymap: false}),
                 Prec.highest(cmKeymap.of(markdownKeymap)),
 
                 links,


### PR DESCRIPTION
This fixes an issue when folding a Markdown block with trailing empty lines. We already get syntax highlighting for markdown blocks through the language parser, todo checkboxes from our custom extension, and we still include the keyboard bindings from the markdown extension.

This will make individual sections within a markdown block not foldable, but I can live with that.

Should fix #195 