### PR TITLE
Add key bindings for Command+ArrowLeft/Right on Mac OS

### DIFF
--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -55,6 +55,8 @@ export const DEFAULT_KEYMAP = [
         cmd("Alt-Delete", "deleteGroupForward"),
         cmd("Mod-Backspace", "deleteLineBoundaryBackward"),
         cmd("Mod-Delete", "deleteLineBoundaryForward"),
+        ...cmdShift("Mod-ArrowLeft", "cursorLineBoundaryBackward", "selectLineBoundaryBackward"),
+        ...cmdShift("Mod-ArrowRight", "cursorLineBoundaryForward", "selectLineBoundaryForward"),
     ] : []),
     
     cmd("Alt-ArrowUp", "moveLineUp"),


### PR DESCRIPTION
Fixes #367