### PR TITLE
Fix removal of additional cursors with Alt+Click, and change default keys for rectangular selection to Alt+Shift-Click

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ You now get a visual representation of open buffers in the form of tabs. The tab
 ### Other fixes and improvements
 
 - Remember the open buffer(s) between program restarts
+- Fixed so that Alt-clicking on an cursor removes it (if more than one cursor exists)
+- Changed the key binding for rectangular selection from Alt+Click to Alt+Shift+Click.
 - Update to latest version of Electron
 
 

--- a/src/editor/crosshair-cursor.js
+++ b/src/editor/crosshair-cursor.js
@@ -1,0 +1,41 @@
+import { EditorView, ViewPlugin } from "@codemirror/view"
+
+
+const showCrosshair = { style: "cursor: crosshair" };
+
+/**
+ * Modified version of CodeMirror's crosshairCursor that takes an eventFilter function instead of a key
+ */
+export function crosshairCursor(options = {}) {
+    const filter = options.eventFilter ? options.eventFilter : e => e.altKey
+
+    let plugin = ViewPlugin.fromClass(class {
+        constructor(view) {
+            this.view = view;
+            this.isDown = false;
+        }
+        set(isDown) {
+            if (this.isDown != isDown) {
+                this.isDown = isDown;
+                this.view.update([]);
+            }
+        }
+    }, {
+        eventObservers: {
+            keydown(e) {
+                //this.set(e.keyCode == code || getter(e));
+                this.set(filter(e))
+            },
+            keyup(e) {
+                this.set(false);
+            },
+            mousemove(e) {
+                this.set(filter(e));
+            }
+        }
+    });
+    return [
+        plugin,
+        EditorView.contentAttributes.of(view => { var _a; return ((_a = view.plugin(plugin)) === null || _a === void 0 ? void 0 : _a.isDown) ? showCrosshair : null; })
+    ];
+}

--- a/src/editor/setup.js
+++ b/src/editor/setup.js
@@ -8,6 +8,8 @@ import { highlightSelectionMatches, searchKeymap } from './codemirror-search/sea
 import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete';
 import { lintKeymap } from '@codemirror/lint';
 
+import { crosshairCursor as customCrosshairCursor} from "./crosshair-cursor.js"
+
 // (The superfluous function calls around the list of extensions work
 // around current limitations in tree-shaking software.)
 /**
@@ -57,13 +59,21 @@ const customSetup = /*@__PURE__*/(() => [
     dropCursor(),
     EditorState.allowMultipleSelections.of(true),
     EditorView.clickAddsSelectionRange.of(e => e.altKey),
+
+    // configure rectangular selection for Alt+Shift+Click 
+    rectangularSelection({
+        eventFilter: e => e.altKey && e.shiftKey
+    }),
+    customCrosshairCursor({
+        eventFilter: e => e.altKey && e.shiftKey
+    }),
+    //crosshairCursor(),
+    
     indentOnInput(),
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
     bracketMatching(),
     //closeBrackets(),
     //autocompletion(),
-    rectangularSelection(),
-    crosshairCursor(),
     highlightActiveLine(),
     //highlightSelectionMatches(),
     EditorView.lineWrapping,

--- a/tests/multiple-cursors.spec.js
+++ b/tests/multiple-cursors.spec.js
@@ -1,0 +1,171 @@
+import { test, expect } from "@playwright/test";
+import { HeynotePage } from "./test-utils.js";
+
+let heynotePage
+
+test.beforeEach(async ({ page }) => {
+    heynotePage = new HeynotePage(page)
+    await heynotePage.goto()
+});
+
+test("Alt+Click creates additional cursor", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞text
+First line of content
+Second line of content
+Third line of content
+`)
+    
+    // Initially should have one cursor
+    let cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(1)
+    
+    // Click on first line to position cursor - use actual text location
+    await page.locator(".cm-line").first().click()
+    await page.waitForTimeout(100)
+    
+    // Alt+Click on second line to add cursor  
+    await page.locator(".cm-line").nth(1).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have two cursors
+    cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(2)
+    
+    // Alt+Click on third line to add another cursor
+    await page.locator(".cm-line").nth(2).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have three cursors
+    cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(3)
+})
+
+test("Alt+Click removes existing cursor when clicking on it", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞text
+First line of content
+Second line of content
+Third line of content
+Fourth line of content
+`)
+    
+    // Click on first line to position cursor
+    await page.locator(".cm-line").first().click()
+    await page.waitForTimeout(100)
+    
+    // Alt+Click to create additional cursors
+    await page.locator(".cm-line").nth(1).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    await page.locator(".cm-line").nth(2).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    await page.locator(".cm-line").nth(3).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have four cursors
+    let cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(4)
+    
+    // Alt+Click on second line cursor to remove it
+    await page.locator(".cm-line").nth(1).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have three cursors
+    cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(3)
+    
+    // Alt+Click on first line cursor to remove it
+    await page.locator(".cm-line").first().click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have two cursors
+    cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(2)
+})
+
+test("Alt+Click works with text selection", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞text
+hello world test
+another line here
+final line content
+`)
+    
+    // Double click to select "hello" in first line
+    await page.locator(".cm-line").first().dblclick()
+    await page.waitForTimeout(100)
+    
+    // Verify we have a selection
+    let selectedText = await page.evaluate(() => {
+        const state = window._heynote_editor.view.state
+        const range = state.selection.ranges[0]
+        return state.doc.sliceString(range.from, range.to)
+    })
+    expect(selectedText).toBe("test")
+    
+    // Alt+Click on second line to add cursor
+    await page.locator(".cm-line").nth(1).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should now have two cursors/selections
+    let cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(2)
+    
+    // Type to replace selected text and add at new cursor
+    await page.locator("body").pressSequentially("replaced")
+    
+    // Check content was updated at both locations
+    const content = await heynotePage.getContent()
+    expect(content).toContain("hello world replaced")
+    expect(content).toContain("another line herereplaced")
+})
+
+test("multiple cursors typing behavior", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞text
+Line 1
+Line 2
+Line 3
+`)
+    
+    // Create multiple cursors at the beginning of each line
+    await page.locator(".cm-line").first().click()
+    await page.waitForTimeout(100)
+    
+    await page.locator(".cm-line").nth(1).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    await page.locator(".cm-line").nth(2).click({ modifiers: ['Alt'] })
+    await page.waitForTimeout(100)
+    
+    // Should have three cursors
+    let cursors = await page.evaluate(() => {
+        return window._heynote_editor.view.state.selection.ranges.length
+    })
+    expect(cursors).toBe(3)
+    
+    // Type some text
+    await page.locator("body").pressSequentially(">> ")
+    
+    // Check that text was added at all cursor positions  
+    const content = await heynotePage.getContent()
+    expect(content).toContain("Line 1>> ")
+    expect(content).toContain("Line 2>> ")
+    expect(content).toContain("Line 3>> ")
+})


### PR DESCRIPTION
Fix conflict when using Alt+Click for both clickAddsSelectionRange and rectangularSelection

* Change rectangular selection to Alt+Shift+Click.
* Add custom crosshairCursor extension that changes the cursor to a crosshair when Alt+Shift is held.
* Add tests for multiple cursors

Supersedes #373 