### PR TITLE
Fix restoring of window position

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ It's now possible to turn on/off spellchecking. This can be done by clicking the
 - Remember the open buffer(s) between program restarts.
 - Fixed so that Alt-clicking on an cursor removes it (if more than one cursor exists).
 - Changed the key binding for rectangular selection from Alt+Click to Alt+Shift+Click.
+- Fixed issue where the window position wouldn't be properly restored in some cases.
 - Updated to latest version of Electron.
 
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -98,19 +98,21 @@ async function createWindow() {
     // windowConfig.x and windowConfig.y will be undefined when config file is missing, e.g. first time run
     if (windowConfig.x !== undefined && windowConfig.y !== undefined) {
         // check if window is outside of screen, or too large
-        const area = screen.getDisplayMatching({
+        const display = screen.getDisplayMatching({
             x: windowConfig.x,
             y: windowConfig.y,
             width: windowConfig.width,
             height: windowConfig.height,
-        }).workArea
+        })
+        //console.log("bounds:", display.bounds, "workArea:", display.workArea)
+        const area = display.workArea
         if (windowConfig.width > area.width) {
             windowConfig.width = area.width
         }
         if (windowConfig.height > area.height) {
             windowConfig.height = area.height
         }
-        if (windowConfig.x + windowConfig.width > area.width || windowConfig.y + windowConfig.height > area.height) {
+        if (windowConfig.x + windowConfig.width > (area.width + area.x) || windowConfig.y + windowConfig.height > (area.height + area.y)) {
             // window is outside of screen, reset position
             windowConfig.x = undefined
             windowConfig.y = undefined


### PR DESCRIPTION
The logic for checking if the windows fits the screen doesn't take any offset (due to OS UI elements such as a menu bar) into account. This could lead to that the window's position wasn't properly restored even though the entire window would fit within the work area. This PR fixes that.