### PR TITLE
Improve how we display keybindings

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Here are the most notable changes in each release. For a more detailed list of c
 
 ## Next version (not yet released)
 
+- Show key bindings in Command Palette
 - When displaying key bindings show shorter version with ⇧, ⌘, ⌥, etc instead of Shift, Cmd, Alt, etc
 - Fixed so that tooltips displays new key binding if the default have been overridden
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,13 @@
 
 Here are the most notable changes in each release. For a more detailed list of changes, see the [Github Releases page](https://github.com/heyman/heynote/releases).
 
-## 2.5.0 (not yet released)
+## Next version (not yet released)
+
+- When displaying key bindings show shorter version with ⇧, ⌘, ⌥, etc instead of Shift, Cmd, Alt, etc
+- Fixed so that tooltips displays new key binding if the default have been overridden
+
+
+## 2.5.0
 
 ### Tabs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Available for Mac, Windows, and Linux.
 ⌘ + N               Create a new note buffer
 ⌘ + S               Move the current block to another (or new) buffer
 ⌘ + P               Open note selector
+⌘ + Shift + P       Open command palette
 ⌘ + Down            Goto next block
 ⌘ + Up              Goto previous block
 ⌘ + A               Select all text in a note block. Press again to select the whole buffer
@@ -65,6 +66,7 @@ Ctrl + L               Change block language
 Ctrl + N               Create a new note buffer
 Ctrl + S               Move the current block to another (or new) buffer
 Ctrl + P               Open note selector
+Ctrl + Shift + P       Open command palette
 Ctrl + Down            Goto next block
 Ctrl + Up              Goto previous block
 Ctrl + A               Select all text in a note block. Press again to select the whole buffer

--- a/shared-utils/key-helper.ts
+++ b/shared-utils/key-helper.ts
@@ -12,6 +12,7 @@ export const keyHelpStr = (platform: string, extended: boolean = false) => {
         [`${modChar} + N`, "Create a new note buffer"],
         [`${modChar} + S`, "Move the current block to another (or new) buffer"],
         [`${modChar} + P`, "Open note selector"],
+        [`${modChar} + Shift + P`, "Open command palette"],
         [`${modChar} + Down`, "Goto next block"],
         [`${modChar} + Up`, "Goto previous block"],
         [`${modChar} + A`, "Select all text in a note block. Press again to select the whole buffer"],

--- a/src/components/BufferSelector.vue
+++ b/src/components/BufferSelector.vue
@@ -4,7 +4,8 @@
     import { mapState, mapActions } from 'pinia'
     import { SCRATCH_FILE_NAME } from "../common/constants"
     import { useHeynoteStore } from "../stores/heynote-store"
-    import { HEYNOTE_COMMANDS } from '../editor/commands'
+    import { useSettingsStore } from "../stores/settings-store"
+    import { HEYNOTE_COMMANDS } from "../editor/commands"
 
     const pathSep = window.heynote.buffer.pathSeparator
 
@@ -50,6 +51,9 @@
                 "buffers",
                 "recentBufferPaths",
             ]),
+            ...mapState(useSettingsStore, [
+                "commandKeyBindingsMap",
+            ]),
 
             commands() {
                 const commands = Object.entries(HEYNOTE_COMMANDS)
@@ -67,6 +71,7 @@
                     name: `${cmd.category}: ${cmd.description}`,
                     cmd: cmdKey,
                     isCommand: true,
+                    bindings: this.commandKeyBindingsMap[cmdKey],
                 }))
             },
 
@@ -258,6 +263,7 @@
                     "action-buttons-visible": this.actionButton > 0,
                     "scratch": item.scratch,
                     "new-note": item.createNew,
+                    "command": item.isCommand,
                 }
             },
 
@@ -318,6 +324,16 @@
                     >
                         <span class="name" v-html="item.name" />
                         <span class="path" v-html="item.folder" />
+                        <span v-if="item.bindings" class="bindings">
+                            <span 
+                                v-for="binding in item.bindings.slice(0, 2)" 
+                                :key="binding" 
+                                class="binding"
+                            > {{ binding }}</span>
+                            <span v-if="item.bindings.length > 2" class="more">
+                                and {{ item.bindings.length - 2 }} more
+                            </span>
+                        </span>
                         <span :class="{'action-buttons':true, 'visible':actionButton > 0 && idx === selected}">
                             <button 
                                 v-if="actionButton > 0 && idx === selected"
@@ -356,7 +372,7 @@
         position: absolute
         top: 0
         left: 50%
-        width: 440px
+        width: 480px
         transform: translateX(-50%)
         max-height: 100%
         box-sizing: border-box
@@ -421,6 +437,7 @@
                 align-items: center
                 scroll-margin-top: 6px
                 scroll-margin-bottom: 6px
+                cursor: pointer
                 &:hover
                     background: #e2e2e2
                     .action-buttons .show-actions
@@ -455,6 +472,9 @@
                     font-weight: 600
                 &.new-note
                     //font-size: 12px
+                &.command
+                    .name
+                        flex-grow: 1
                 .name
                     max-width: 100%
                     margin-right: 12px
@@ -473,6 +493,21 @@
                     text-wrap: nowrap
                     ::v-deep(b)
                         font-weight: 700
+                .bindings
+                    opacity: 0.6
+                    font-size: 12px
+                    flex-shrink: 1
+                    overflow: hidden
+                    text-overflow: ellipsis
+                    text-wrap: nowrap
+                    .binding
+                        display: inline-block
+                        margin-right: 10px
+                        &:last-child
+                            margin-right: 0
+                    .more
+                        font-style: italic
+                    
                 .action-buttons
                     position: absolute
                     top: 1px

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -2,6 +2,7 @@
     import { mapState } from 'pinia'
     import UpdateStatusItem from './UpdateStatusItem.vue'
     import { LANGUAGES } from '../editor/languages.js'
+    import { getKeyBindingForCommand } from '../editor/keymap.js'
     import { useHeynoteStore } from "../stores/heynote-store"
     import { useSettingsStore } from "../stores/settings-store"
     
@@ -40,6 +41,7 @@
             ...mapState(useSettingsStore, [
                 "spellcheckEnabled",
                 "alwaysOnTop",
+                "settings",
             ]),
 
             languageName() {
@@ -63,14 +65,6 @@
                 return `Format Block Content (Alt + Shift + F)`
             },
 
-            changeNoteTitle() {
-                return `Change Note (${this.cmdKey} + P)`
-            },
-
-            changeLanguageTitle() {
-                return `Change language for current block (${this.cmdKey} + L)`
-            },
-
             updatesEnabled() {
                 return !!window.heynote.autoUpdate
             },
@@ -81,6 +75,11 @@
                 event.preventDefault()
                 window.heynote.mainProcess.invoke('showSpellcheckingContextMenu')
             },
+
+            getTooltip(text, command) {
+                const binding = getKeyBindingForCommand(command, this.settings.keymap, this.settings.keyBindings, this.settings.emacsMetaKey)
+                return !binding ? text : `${text} (${binding})`
+            }
         },
     }
 </script>
@@ -98,14 +97,14 @@
         <div 
             @click.stop="$emit('openBufferSelector')"
             class="status-block note clickable"
-            :title="changeNoteTitle"
+            :title="getTooltip('Change Note', 'openBufferSelector')"
         >
             {{ currentBufferName }} 
         </div>
         <div 
             @click.stop="$emit('openLanguageSelector')"
             class="status-block lang clickable"
-            :title="changeLanguageTitle"
+            :title="getTooltip('Change language for current block', 'openLanguageSelector')"
         >
             {{ languageName }} 
             <span v-if="currentLanguageAuto" class="auto">(auto)</span>
@@ -114,7 +113,7 @@
             v-if="supportsFormat"
             @click.stop="$emit('formatCurrentBlock')"
             class="status-block format clickable"
-            :title="formatBlockTitle"
+            :title="getTooltip('Format Block Content', 'formatBlockContent')"
         >
             <span class="icon icon-format"></span>
         </div>
@@ -123,7 +122,7 @@
             @mousedown.prevent
             @contextmenu="onSpellcheckingContextMenu"
             :class="'status-block spellcheck clickable' + (this.spellcheckEnabled ? ' spellcheck-enabled' : '')"
-            title="Spellchecking"
+            :title="getTooltip('Spellchecking', 'toggleSpellcheck')"
         >
             <span class="icon icon-format"></span>
         </div>
@@ -133,7 +132,7 @@
             @click.stop="$emit('toggleAlwaysOnTop')"
             @mousedown.prevent
             class="status-block pin clickable"
-            title="Pin"
+            :title="getTooltip('Pin', 'toggleAlwaysOnTop')"
         >
             <span class="icon icon-format" :class="{'pinned': alwaysOnTop}"></span>
         </div>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -2,7 +2,6 @@
     import { mapState } from 'pinia'
     import UpdateStatusItem from './UpdateStatusItem.vue'
     import { LANGUAGES } from '../editor/languages.js'
-    import { getKeyBindingForCommand } from '../editor/keymap.js'
     import { useHeynoteStore } from "../stores/heynote-store"
     import { useSettingsStore } from "../stores/settings-store"
     
@@ -42,6 +41,7 @@
                 "spellcheckEnabled",
                 "alwaysOnTop",
                 "settings",
+                "commandKeyBindingsMap",
             ]),
 
             languageName() {
@@ -77,8 +77,8 @@
             },
 
             getTooltip(text, command) {
-                const binding = getKeyBindingForCommand(command, this.settings.keymap, this.settings.keyBindings, this.settings.emacsMetaKey)
-                return !binding ? text : `${text} (${binding})`
+                const bindings = this.commandKeyBindingsMap[command]
+                return bindings.length === 0 ? text : `${text} (${bindings[0]})`
             }
         },
     }

--- a/src/components/settings/KeyBindRow.vue
+++ b/src/components/settings/KeyBindRow.vue
@@ -1,5 +1,10 @@
 <script>
+    import { mapState } from 'pinia'
+
     import { HEYNOTE_COMMANDS } from '@/src/editor/commands'
+    import { getKeyBindingLabel } from '@/src/editor/keymap'
+    import { useSettingsStore } from '@/src/stores/settings-store'
+
     
     export default {
         props: [
@@ -10,11 +15,10 @@
         ],
 
         computed: {
+            ...mapState(useSettingsStore, ["settings"]),
+
             formattedKeys() {
-                return this.keys.replaceAll(
-                    "Mod", 
-                    window.heynote.platform.isMac ? "⌘" : "Ctrl",
-                )
+                return getKeyBindingLabel(this.keys, this.settings.emacsMetaKey, "&nbsp;&nbsp;&nbsp;")
             },
 
             commandLabel() {
@@ -38,9 +42,7 @@
             {{ source }}
         </td>
         <td class="key">
-            <template v-if="keys">
-                {{ formattedKeys }}
-            </template>
+            <span v-if="keys" v-html="formattedKeys" />
         </td>
         <td class="command">
             <span class="command-name">{{ commandLabel }}</span>

--- a/src/components/settings/RecordKeyInput.vue
+++ b/src/components/settings/RecordKeyInput.vue
@@ -1,4 +1,9 @@
 <script>
+    import { mapState } from 'pinia'
+    
+    import { getKeyBindingLabel } from '@/src/editor/keymap'
+    import { useSettingsStore } from '@/src/stores/settings-store'
+
     import { keyName, base } from "w3c-keyname"
 
     export default {
@@ -13,8 +18,14 @@
         },
 
         computed: {
+            ...mapState(useSettingsStore, ["settings"]),
+            
             key() {
                 return this.keys.join(" ")
+            },
+
+            keyLabel() {
+                return getKeyBindingLabel(this.key, this.settings.emacsMetaKey, "     ")
             },
         },
 
@@ -80,7 +91,7 @@
 <template>
     <input 
         type="text" 
-        :value="key" 
+        :value="keyLabel" 
         @keydown.prevent="onKeyDown"
         class="keys"
         readonly

--- a/src/editor/commands.js
+++ b/src/editor/commands.js
@@ -84,9 +84,11 @@ const switchToLastTab = (editor) => () => {
 }
 const nextTab = (editor) => () => {
     useHeynoteStore().nextTab()
+    return true
 }
 const previousTab = (editor) => () => {
     useHeynoteStore().previousTab()
+    return true
 }
 
 export function toggleAlwaysOnTop(editor) {
@@ -151,6 +153,7 @@ const HEYNOTE_COMMANDS = {
         "switchToTab" + (i+1), 
         cmdLessContext(() => {
             useHeynoteStore().switchToTabIndex(i)
+            return true
         }, "Buffer", `Switch to tab ${i+1}`),
     ])),
 

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -247,7 +247,7 @@ export function getKeyBindingLabel(binding, emacsMetaKey, separator=" ") {
                 return key.toUpperCase()
             }
             return key
-        }).join(parts.length === 1 ? " + " : "+")
+        }).join("+")
     }).join(separator)
 }
 
@@ -289,7 +289,8 @@ function _canonicalizeSingleStroke(strokeString) {
 /**
  * Returns the first bound key for a command (in label format, i.e. Mod replaced with ⌘ etc.)
  */
-export function getKeyBindingForCommand(command, keymapName, userKeymap, emacsMetaKey) {
+export function getAllKeyBindingsForCommand(command, keymapName, userKeymap, emacsMetaKey) {
+    //console.log("debug:", "getKeyBindingForCommand", command, keymapName, userKeymap, emacsMetaKey)
     const capturingCommands = new Set([
         "nothing", 
         "toggleAlwaysOnTop", 
@@ -299,16 +300,24 @@ export function getKeyBindingForCommand(command, keymapName, userKeymap, emacsMe
     ])
 
     const capturedKeys = new Set()
+    const bindings = []
     
 
     for (const binding of getCombinedKeymapSpec(keymapName, userKeymap)) {
         const key = canonicalizeKey(binding.key)
         if (binding.command === command && !capturedKeys.has(key)) {
-            return getKeyBindingLabel(binding.key, emacsMetaKey)
+            bindings.push(getKeyBindingLabel(binding.key, emacsMetaKey))
         }
         
         if (capturingCommands.has(binding.command)) {
             capturedKeys.add(key)
         }
     }
+    return bindings
+}
+
+export function getCommandKeyBindings(keymapName, userKeymap, emacsMetaKey) {
+    return Object.fromEntries(Object.keys(HEYNOTE_COMMANDS).map((cmd) => {
+        return [cmd, getAllKeyBindingsForCommand(cmd, keymapName, userKeymap, emacsMetaKey)]
+    }))
 }

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -1,7 +1,11 @@
 import { keymap } from "@codemirror/view"
 import { Prec } from "@codemirror/state"
 
+import { keyName } from "w3c-keyname"
+
+
 import { HEYNOTE_COMMANDS } from "./commands.js"
+
 
 const cmd = (key, command, scope) => ({key, command, scope})
 const cmdShift = (key, command, shiftCommand) => {
@@ -203,19 +207,108 @@ function keymapFromSpec(specs, editor) {
 }
 
 
-export function heynoteKeymap(editor, keymap, userKeymap) {
+function getCombinedKeymapSpec(keymapName, userKeymap) {
     return [
-        keymapFromSpec([
-            ...userKeymap,
-            ...keymap,
-        ], editor),
+        ...userKeymap,
+        ...(keymapName === "emacs" ? [...EMACS_KEYMAP, ...DEFAULT_KEYMAP] : [...DEFAULT_NOT_EMACS_KEYMAP, ...DEFAULT_KEYMAP]),
     ]
 }
 
 export function getKeymapExtensions(editor, keymap, keyBindings) {
-    return heynoteKeymap(
-        editor, 
-        keymap === "emacs" ? [...EMACS_KEYMAP, ...DEFAULT_KEYMAP] : [...DEFAULT_NOT_EMACS_KEYMAP, ...DEFAULT_KEYMAP],
-        keyBindings || [],
-    )
+    return [
+        keymapFromSpec(getCombinedKeymapSpec(keymap, keyBindings), editor)
+    ]
+}
+
+/**
+ * @returns Human readable version of a key binding
+ */
+export function getKeyBindingLabel(binding, emacsMetaKey, separator=" ") {
+    emacsMetaKey = emacsMetaKey === "meta" ? "Meta" : (emacsMetaKey === "alt" ? "Alt" : emacsMetaKey)
+
+    const parts = binding.split(" ")
+    return parts.map((part) => {
+        return part.split("-").map((key) => {
+            switch(key) {
+                case "Mod":
+                    return window.heynote.platform.isMac ? "⌘" : "Ctrl"
+                case "Alt":
+                    return window.heynote.platform.isMac ? "⌥" : "Alt"
+                case "EmacsMeta":
+                    return emacsMetaKey === "Meta" ? "Meta" : (emacsMetaKey === "Alt" ? "Alt" : emacsMetaKey)
+                case "Meta":
+                    return window.heynote.platform.isMac ? "⌘" : "Meta"
+                case "Shift":
+                    return "⇧"
+                case "Control":
+                    return "Ctrl"
+            }
+            if (key.match(/^[a-z]$/)) {
+                return key.toUpperCase()
+            }
+            return key
+        }).join(parts.length === 1 ? " + " : "+")
+    }).join(separator)
+}
+
+
+
+function canonicalizeKey(keyString) {
+    const strokes = keyString.trim().split(/\s+/)
+    return strokes.map(stroke => _canonicalizeSingleStroke(stroke)).join(' ')
+}
+function _canonicalizeSingleStroke(strokeString) {
+    const parts = strokeString.split('-')
+    const key = parts.pop()
+    const modifiers = parts.map(mod => mod.toLowerCase())
+
+    const normalizedModifiers = modifiers.map(mod => {
+        switch (mod) {
+            case 'mod': return isMac ? 'meta' : 'ctrl'
+            case 'control': case 'ctrl': return 'ctrl'
+            case 'shift': return 'shift'
+            case 'alt': case 'option': return 'alt'
+            case 'meta': case 'cmd': case 'command': return 'meta'
+            default: return mod
+        }
+    })
+
+    const order = ['ctrl', 'alt', 'shift', 'meta']
+    const sortedModifiers = normalizedModifiers.sort((a, b) => {
+        return order.indexOf(a) - order.indexOf(b)
+    })
+
+    const uniqueModifiers = [...new Set(sortedModifiers)]
+
+    return uniqueModifiers.length > 0
+        ? uniqueModifiers.join('-') + '-' + key.toLowerCase()
+        : key.toLowerCase()
+}
+
+
+/**
+ * Returns the first bound key for a command (in label format, i.e. Mod replaced with ⌘ etc.)
+ */
+export function getKeyBindingForCommand(command, keymapName, userKeymap, emacsMetaKey) {
+    const capturingCommands = new Set([
+        "nothing", 
+        "toggleAlwaysOnTop", 
+        "openLanguageSelector", "openBufferSelector", "openCreateNewBuffer", "openMoveToBuffer", "openCommandPalette", 
+        "closeCurrentTab", "reopenLastClosedTab", "nextTab", "previousTab", 
+        "switchToTab1", "switchToTab2", "switchToTab3", "switchToTab4", "switchToTab5", "switchToTab6", "switchToTab7", "switchToTab8", "switchToTab9", "switchToLastTab"
+    ])
+
+    const capturedKeys = new Set()
+    
+
+    for (const binding of getCombinedKeymapSpec(keymapName, userKeymap)) {
+        const key = canonicalizeKey(binding.key)
+        if (binding.command === command && !capturedKeys.has(key)) {
+            return getKeyBindingLabel(binding.key, emacsMetaKey)
+        }
+        
+        if (capturingCommands.has(binding.command)) {
+            capturedKeys.add(key)
+        }
+    }
 }

--- a/src/stores/settings-store.js
+++ b/src/stores/settings-store.js
@@ -1,7 +1,8 @@
-import { toRaw } from 'vue'
+import { toRaw } from "vue"
 import { defineStore } from "pinia"
 
-import { SETTINGS_CHANGE_EVENT } from '@/src/common/constants'
+import { SETTINGS_CHANGE_EVENT } from "@/src/common/constants"
+import { getCommandKeyBindings } from "@/src/editor/keymap"
 
 export const useSettingsStore = defineStore("settings", {
     state: () => {
@@ -13,6 +14,13 @@ export const useSettingsStore = defineStore("settings", {
             alwaysOnTop: window.heynote.settings.alwaysOnTop,
         }
     },
+
+    getters: {
+        commandKeyBindingsMap(state) {
+            return getCommandKeyBindings(state.settings.keymap, state.settings.keyBindings, state.settings.emacsMetaKey)
+        },
+    },
+        
 
     actions: {
         onSettingsChange(settings) {

--- a/tests/custom-key-bindings.spec.js
+++ b/tests/custom-key-bindings.spec.js
@@ -29,6 +29,11 @@ test("add custom key binding", async ({page}) => {
     await page.locator("css=.overlay .settings .dialog .bottom-bar .close").click()
     await page.locator("body").press("Control+Shift+H")
     await expect(page.locator("css=.language-selector .items > li.selected")).toBeVisible()
+    await page.locator("body").press("Escape")
+    await expect(page.locator("css=.status .status-block.lang")).toHaveAttribute(
+        "title", 
+        "Change language for current block (Ctrl + ⇧ + H)"
+    )
 })
 
 test("delete custom key binding", async ({page}) => {
@@ -70,4 +75,8 @@ test("disable default key binding", async ({page}) => {
     await heynotePage.setSettings(settings)
     await page.locator("body").press(langKey)
     await expect(page.locator("css=.language-selector .items > li.selected")).toHaveCount(0)
+    await expect(page.locator("css=.status .status-block.lang")).toHaveAttribute(
+        "title", 
+        "Change language for current block"
+    )
 })

--- a/tests/custom-key-bindings.spec.js
+++ b/tests/custom-key-bindings.spec.js
@@ -32,7 +32,7 @@ test("add custom key binding", async ({page}) => {
     await page.locator("body").press("Escape")
     await expect(page.locator("css=.status .status-block.lang")).toHaveAttribute(
         "title", 
-        "Change language for current block (Ctrl + ⇧ + H)"
+        "Change language for current block (Ctrl+⇧+H)"
     )
 })
 
@@ -79,4 +79,15 @@ test("disable default key binding", async ({page}) => {
         "title", 
         "Change language for current block"
     )
+})
+
+test("open command palette", async ({page}) => {
+    const langKey = heynotePage.isMac ? "Meta+Shift+P" : "Control+Shift+P"
+    await page.locator("body").press(langKey)
+    await expect(page.locator("css=.note-selector .input-container input")).toHaveValue(">")
+    await expect(page.locator("css=.note-selector .items > li.selected")).toBeVisible()
+    await page.locator("body").pressSequentially("create new")
+    await expect(page.locator("css=.note-selector .items > li.selected .name")).toHaveText("Buffer: Create new buffer…")
+    await expect(page.locator("css=.note-selector .items > li.selected .bindings .binding")).toBeVisible()
+    await page.locator("body").press("Escape")
 })


### PR DESCRIPTION
* Show key bindings in Command Palette
* Use shorter label version with ⇧, ⌘, ⌥, etc when displaying key bindings in the UI
* Use dynamic key bindings in tooltips (instead of hardcoded strings), so that the new key binding is displayed if a default has been overridden.