### PR TITLE
Fix issue with large Math blocks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 Here are the most notable changes in each release. For a more detailed list of changes, see the [Github Releases page](https://github.com/heyman/heynote/releases).
 
+## 2.6.2 (not yet released)
+
+- Fix issue that would break Math blocks with a large number of lines (the parser would not start processing 
+  rows from the beginning of the block)
+
 ## 2.6.1
 
 - Fix crash when no custom key binding had been set

--- a/src/editor/block/math.js
+++ b/src/editor/block/math.js
@@ -53,6 +53,14 @@ function mathDeco(view) {
                 // get math.js parser and cache it for this block
                 let {parser, prev} = mathParsers.get(block) || {}
                 if (!parser) {
+                    if (line.from > block.content.from) {
+                        // this means that the first line of the visible ranges is in the middle of a math block
+                        // and in this case we want to start processing from the start of the math block to ensure 
+                        // that each of the Math block's lines get processed
+                        //console.log("whole match block not within visible ranges!")
+                        pos = block.content.from
+                        continue
+                    }
                     parser = window.math.parser()
                     mathParsers.set(block, {parser, prev})
                 }

--- a/tests/math.spec.js
+++ b/tests/math.spec.js
@@ -56,3 +56,27 @@ prev
     await expect(page.locator("css=.heynote-math-result").last()).toHaveText("1337")
 })
 
+
+test("each row of math blocks are processed even if they are outside of visible ranges", async ({ page }) => {
+    let bufferContent = `
+∞∞∞math
+a = 0`
+
+    for (let i=0; i<=200; i++) {
+        bufferContent += "\na = a + 1"
+    }
+    await heynotePage.setContent(bufferContent)
+
+    // scroll all the way up
+    for (let i=0; i<=20; i++)
+        await page.locator("body").press("PageUp");
+    await page.waitForTimeout(100)
+
+    // scroll all the way up to make the first rows of the block outside visible ranges
+    for (let i=0; i<=20; i++)
+        await page.locator("body").press("PageDown");
+    await page.waitForTimeout(100)
+
+    // make sure the whole Math block was processed
+    await expect(page.locator("css=.heynote-math-result").last()).toHaveText("201")
+})


### PR DESCRIPTION
Fix issue that would break Math blocks with a large number of lines (the parser would not start processing rows from the beginning of the block).

Fixes #389 