### PR TITLE
Downgrade Electron to 39.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "codemirror-lang-elixir": "^4.0.0",
         "codemirror-lang-mermaid": "^0.5.0",
         "debounce": "^1.2.1",
-        "electron": "^40.0.0",
+        "electron": "^39.3.0",
         "electron-builder": "^26.4.0",
         "electron-store": "^8.1.0",
         "electron-updater": "^6.6.2",
@@ -4552,15 +4552,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.0.0.tgz",
-      "integrity": "sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==",
+      "version": "39.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.3.0.tgz",
+      "integrity": "sha512-ZA2Cmu5Vs8zeuZBr71XWZ5vgm7lRDB9N50oV6ee7YocITyxRxx/apWFKY48Sxyn0gzVlX+6YQc3CS1PtYIkGUg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -4863,19 +4863,19 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "version": "22.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
+      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "codemirror-lang-elixir": "^4.0.0",
     "codemirror-lang-mermaid": "^0.5.0",
     "debounce": "^1.2.1",
-    "electron": "^40.0.0",
+    "electron": "^39.3.0",
     "electron-builder": "^26.4.0",
     "electron-store": "^8.1.0",
     "electron-updater": "^6.6.2",


### PR DESCRIPTION
Performance degradation running Heynote with the latest version of Electron (40) was reported (#431). This PR downgrades Electron to the latest 39.x.x version.