### PR TITLE
Sanitize system locale

### DIFF
--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -1,6 +1,7 @@
 import { toRaw, nextTick, watch } from 'vue';
 import { defineStore } from "pinia"
 import { NoteFormat } from "../common/note-format"
+import { toSafeBrowserLocale } from "../util/locale.js"
 import { useEditorCacheStore } from "./editor-cache"
 import { 
     SCRATCH_FILE_NAME, WINDOW_FULLSCREEN_STATE, WINDOW_FOCUS_STATE, 
@@ -380,5 +381,5 @@ export async function initHeynoteStore() {
     watch(() => heynoteStore.currentBufferPath, () => heynoteStore.saveTabsState())
     watch(() => heynoteStore.openTabs, () => heynoteStore.saveTabsState())
 
-    heynoteStore.systemLocale = await window.heynote.getSystemLocale()
+    heynoteStore.systemLocale = toSafeBrowserLocale(await window.heynote.getSystemLocale())
 }

--- a/src/util/locale.js
+++ b/src/util/locale.js
@@ -1,0 +1,23 @@
+export function toSafeBrowserLocale(locale) {
+    // first attempt: maybe it's already fine
+    try {
+        return Intl.getCanonicalLocales(locale)[0];
+    } catch { }
+
+    //  underscores -> hyphens (en_US -> en-US)
+    locale = locale.replace(/_/g, "-")
+    // drop ".UTF-8", ".utf8", etc.
+    locale = locale.replace(/\.[A-Za-z0-9_-]+$/, "")
+
+    // If there's an ICU/POSIX modifier like @calendar=... or @euro, we must drop it 
+    // (Intl doesn’t understand "@...").
+    locale = locale.split("@", 1)[0];
+
+    // try again after normalization
+    try {
+        return Intl.getCanonicalLocales(locale)[0]
+    } catch { }
+
+    // last resort
+    return navigator.language
+}


### PR DESCRIPTION
Fixes issue when local returned by Electron's getSystemLocale() contains locale extension syntax

Fixes #434 