### PR TITLE
feat: add optional document list sidebar (tree view)

### DIFF
--- a/assets/icons/document-list-dark.svg
+++ b/assets/icons/document-list-dark.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- [|] style: vertical bar (sidebar) on the left -->
+  <rect x="5" y="4" width="4" height="16" rx="1" fill="rgba(255,255,255,0.8)"/>
+  <rect x="13" y="4" width="6" height="16" rx="1" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="1.5"/>
+</svg>

--- a/assets/icons/document-list-light.svg
+++ b/assets/icons/document-list-light.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- [|] style: vertical bar (sidebar) on the left -->
+  <rect x="5" y="4" width="4" height="16" rx="1" fill="#555"/>
+  <rect x="13" y="4" width="6" height="16" rx="1" fill="none" stroke="#555" stroke-width="1.5"/>
+</svg>

--- a/electron/config.js
+++ b/electron/config.js
@@ -48,6 +48,8 @@ const schema = {
             "showFoldGutter": {type: "boolean", default:true},
             "showTabs": {type: "boolean", default: true},
             "showTabsInFullscreen": {type: "boolean", default: true},
+            "showDocumentListSidebar": {type: "boolean", default: false},
+            "documentListSidebarWidth": {type: "integer", default: 200},
             "autoUpdate": {type: "boolean", default: true},
             "allowBetaVersions": {type: "boolean", default: false},
             "enableGlobalHotkey": {type: "boolean", default: false},

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -20,6 +20,7 @@
     import NewBuffer from './NewBuffer.vue'
     import EditBuffer from './EditBuffer.vue'
     import TabBar from './tabs/TabBar.vue'
+    import DocumentListSidebar from './DocumentListSidebar.vue'
     import DrawImageModal from './draw/DrawImageModal.vue'
 
     export default {
@@ -33,6 +34,7 @@
             NewBuffer,
             EditBuffer,
             TabBar,
+            DocumentListSidebar,
             DrawImageModal,
         },
 
@@ -141,6 +143,10 @@
                     return true
                 }
             },
+
+            showDocumentListSidebar() {
+                return this.settings.showDocumentListSidebar === true
+            },
         },
 
         methods: {
@@ -237,9 +243,14 @@
 <template>
     <TabBar v-if="showTabBar" />
     <div 
-        class="container" 
-        :class="{'tab-bar-visible':showTabBar}"
+        class="main-layout" 
+        :class="{'tab-bar-visible': showTabBar, 'sidebar-visible': showDocumentListSidebar}"
     >
+        <DocumentListSidebar v-if="showDocumentListSidebar" class="document-list-sidebar" />
+        <div 
+            class="container" 
+            :class="{'tab-bar-visible': showTabBar}"
+        >
         <Editor 
             v-if="currentBufferPath"
             :theme="settingsStore.theme"
@@ -306,12 +317,23 @@
             />
             <ErrorMessages />
         </div>
+        </div>
     </div>
 </template>
 
 <style scoped lang="sass">
-    .container
+    .main-layout
+        display: flex
         width: 100%
+        height: 100%
+        min-height: 0
+        &.tab-bar-visible
+            height: calc(100% - var(--tab-bar-height))
+        &.sidebar-visible .container
+            min-width: 0
+    .container
+        flex: 1
+        min-width: 0
         height: 100%
         position: relative
         &.tab-bar-visible

--- a/src/components/DocumentListSidebar.vue
+++ b/src/components/DocumentListSidebar.vue
@@ -1,0 +1,380 @@
+<script>
+    import { mapStores, mapState } from 'pinia'
+    import { useHeynoteStore } from "@/src/stores/heynote-store"
+    import { useSettingsStore } from "@/src/stores/settings-store"
+    import { getBlocks, getActiveNoteBlock } from "@/src/editor/block/block.js"
+
+    const MIN_WIDTH = 140
+    const MAX_WIDTH = 400
+    const DEFAULT_WIDTH = 200
+
+    function clampWidth(w) {
+        return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, w))
+    }
+
+    function blockPreview(state, block, maxLen = 24) {
+        const line = state.doc.sliceString(block.content.from, block.content.to).split('\n')[0] || ''
+        const trimmed = line.trim()
+        return trimmed.length > maxLen ? trimmed.slice(0, maxLen) + '…' : trimmed
+    }
+
+    export default {
+        name: 'DocumentListSidebar',
+        data() {
+            return {
+                dragging: false,
+                resizeStartX: 0,
+                resizeStartWidth: 0,
+                dragWidth: 0,
+                expandedPath: null,
+            }
+        },
+        computed: {
+            ...mapStores(useHeynoteStore, useSettingsStore),
+            ...mapState(useHeynoteStore, ['openTabs', 'currentBufferPath', 'blockListVersion']),
+            storedWidth() {
+                const w = this.settingsStore.settings.documentListSidebarWidth
+                return typeof w === 'number' && w > 0 ? w : DEFAULT_WIDTH
+            },
+            sidebarWidth() {
+                if (this.dragging) {
+                    return clampWidth(this.dragWidth)
+                }
+                return clampWidth(this.storedWidth)
+            },
+            items() {
+                return this.openTabs.map((path) => ({
+                    path,
+                    title: this.heynoteStore.getBufferTitle(path),
+                    active: path === this.currentBufferPath,
+                    expanded: this.expandedPath === path,
+                }))
+            },
+            expandedBlocks() {
+                this.blockListVersion // reactive dependency for doc changes
+                if (this.expandedPath !== this.currentBufferPath) return []
+                const editor = this.heynoteStore.currentEditor
+                if (!editor?.view?.state) return []
+                const state = editor.view.state
+                const rawBlocks = getBlocks(state)
+                const active = getActiveNoteBlock(state)
+                return rawBlocks.map((block, index) => {
+                    const isEmpty = block.content.from === block.content.to
+                    const preview = blockPreview(state, block)
+                    const label = isEmpty ? '(empty)' : (preview || block.language?.name || 'text')
+                    return { index, block, label, active: active === block }
+                })
+            },
+        },
+        methods: {
+            onSelect(path) {
+                this.heynoteStore.openBuffer(path)
+                this.expandedPath = path
+                this.heynoteStore.focusEditor()
+            },
+            onExpandClick(path, event) {
+                event.stopPropagation()
+                this.expandedPath = this.expandedPath === path ? null : path
+                if (this.expandedPath && path !== this.currentBufferPath) this.onSelect(path)
+            },
+            goToBlock(block, event) {
+                event.stopPropagation()
+                const editor = this.heynoteStore.currentEditor
+                if (!editor?.view?.state) return
+                const state = editor.view.state
+                const { from, to } = block.content
+                const pos = to > from ? state.doc.lineAt(to - 1).to : from
+                editor.setCursorPosition(pos)
+                this.heynoteStore.focusEditor()
+            },
+            onClose(path, event) {
+                event.stopPropagation()
+                if (this.expandedPath === path) this.expandedPath = null
+                this.heynoteStore.closeTab(path)
+            },
+            onContextMenu(path, event) {
+                event.preventDefault()
+                window.heynote?.mainProcess?.invoke?.('showTabContextMenu', path)
+            },
+            startResize(event) {
+                if (event.button !== 0) return
+                this.dragging = true
+                this.resizeStartX = event.clientX
+                this.resizeStartWidth = this.sidebarWidth
+                this.dragWidth = this.resizeStartWidth
+                document.addEventListener('mousemove', this.onResize)
+                document.addEventListener('mouseup', this.endResize)
+            },
+            onResize(event) {
+                if (!this.dragging) return
+                const delta = event.clientX - this.resizeStartX
+                this.dragWidth = clampWidth(this.resizeStartWidth + delta)
+            },
+            endResize() {
+                if (!this.dragging) return
+                this.dragging = false
+                document.removeEventListener('mousemove', this.onResize)
+                document.removeEventListener('mouseup', this.endResize)
+                this.settingsStore.updateSettings({ documentListSidebarWidth: clampWidth(this.dragWidth) })
+            },
+        },
+    }
+</script>
+
+<template>
+    <aside class="document-list-sidebar" :style="{ width: sidebarWidth + 'px' }">
+        <div class="sidebar-header">Documents</div>
+        <ul class="document-tree">
+            <template v-for="item in items" :key="item.path">
+                <li class="tree-node tree-node-document">
+                    <div
+                        :class="['node-row', 'document-row', { active: item.active }]"
+                        :title="item.title"
+                        @click="onSelect(item.path)"
+                        @contextmenu="onContextMenu(item.path, $event)"
+                    >
+                        <button
+                            type="button"
+                            class="expand"
+                            :class="{ expanded: item.expanded }"
+                            :aria-label="item.expanded ? 'Collapse' : 'Expand'"
+                            tabindex="-1"
+                            @click="onExpandClick(item.path, $event)"
+                        />
+                        <span class="document-title">{{ item.title }}</span>
+                        <button
+                            type="button"
+                            class="close"
+                            tabindex="-1"
+                            aria-label="Close"
+                            @click="onClose(item.path, $event)"
+                        />
+                    </div>
+                    <ul
+                        v-if="item.expanded && item.path === currentBufferPath"
+                        class="tree-children"
+                    >
+                        <li
+                            v-for="(entry, idx) in expandedBlocks"
+                            :key="entry.index"
+                            class="tree-node tree-node-block"
+                        >
+                            <div
+                                :class="['node-row', 'block-row', { active: entry.active }]"
+                                :title="entry.label"
+                                @click="goToBlock(entry.block, $event)"
+                            >
+                                <span class="tree-prefix">{{ idx === expandedBlocks.length - 1 ? '└' : '├' }}── </span>
+                                <span class="block-label">{{ entry.label }}</span>
+                            </div>
+                        </li>
+                    </ul>
+                </li>
+            </template>
+        </ul>
+        <div
+            class="resize-handle"
+            aria-label="Resize sidebar"
+            @mousedown.prevent="startResize"
+        />
+    </aside>
+</template>
+
+<style lang="sass" scoped>
+.document-list-sidebar
+    flex-shrink: 0
+    position: relative
+    min-width: 140px
+    max-width: 400px
+    display: flex
+    flex-direction: column
+    background: var(--panel-background)
+    border-right: 1px solid var(--tab-bar-border-bottom-color)
+    overflow: hidden
+
+.sidebar-header
+    flex-shrink: 0
+    padding: 8px 12px
+    font-size: 12px
+    font-weight: 600
+    color: rgba(0, 0, 0, 0.7)
+    border-bottom: 1px solid var(--tab-bar-border-bottom-color)
+    +dark-mode
+        color: rgba(255, 255, 255, 0.7)
+
+.document-tree
+    flex: 1
+    list-style: none
+    margin: 0
+    padding: 6px 8px
+    overflow-y: auto
+    min-width: 0
+
+.tree-node
+    list-style: none
+    margin: 0
+    padding: 0
+    min-width: 0
+
+.node-row
+    display: flex
+    align-items: center
+    min-width: 0
+    cursor: pointer
+    user-select: none
+    overflow: hidden
+    border-top: 1px solid transparent
+    border-bottom: 1px solid transparent
+
+.document-row
+    min-height: 28px
+    padding: 5px 8px
+    margin-bottom: 2px
+    line-height: 1.4
+    color: rgba(0, 0, 0, 0.6)
+    +dark-mode
+        color: rgba(255, 255, 255, 0.5)
+    &:hover
+        background: #e0e0e0
+        color: rgba(0, 0, 0, 0.9)
+        .close
+            display: block
+        +dark-mode
+            background: #3a3a3a
+            color: rgba(255, 255, 255, 0.9)
+    &.active
+        background: var(--tab-active-bg)
+        color: rgba(0, 0, 0, 0.9)
+        border-color: var(--tab-active-bg)
+        .close
+            display: block
+        +dark-mode
+            color: rgba(255, 255, 255, 0.85)
+            background: var(--tab-active-bg)
+            border-color: var(--tab-active-bg)
+
+.expand
+    flex-shrink: 0
+    width: 20px
+    height: 20px
+    margin-right: 2px
+    padding: 0
+    border: none
+    background: none
+    background-image: url("@/assets/icons/caret-right.svg")
+    background-repeat: no-repeat
+    background-size: 12px
+    background-position: center
+    cursor: pointer
+    opacity: 0.8
+    +dark-mode
+        background-image: url("@/assets/icons/caret-right-white.svg")
+    &:hover
+        opacity: 1
+    &.expanded
+        background-image: url("@/assets/icons/caret-down.svg")
+        +dark-mode
+            background-image: url("@/assets/icons/caret-down-white.svg")
+
+.document-title
+    flex: 1
+    min-width: 0
+    font-size: 12px
+    line-height: 1.4
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+    padding: 0 4px
+
+.close
+    display: none
+    flex-shrink: 0
+    width: 20px
+    height: 20px
+    margin-left: 2px
+    padding: 0
+    border: none
+    background: none
+    background-image: url("@/assets/icons/close.svg")
+    background-repeat: no-repeat
+    background-size: 14px
+    background-position: center
+    border-radius: 3px
+    cursor: pointer
+    opacity: 0.7
+    &:hover
+        background-color: rgba(0, 0, 0, 0.15)
+        opacity: 1
+        +dark-mode
+            background-color: rgba(255, 255, 255, 0.15)
+
+.tree-children
+    list-style: none
+    margin: 0 0 6px 0
+    padding: 0 0 0 8px
+    min-width: 0
+
+.tree-node-block
+    margin: 0
+    padding: 0
+
+.block-row
+    padding: 2px 4px 2px 2px
+    margin-left: 12px
+    font-size: 11px
+    line-height: 1.45
+    min-width: 0
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+    border-radius: 3px
+    border: 1px solid transparent
+    color: rgba(0, 0, 0, 0.55)
+    +dark-mode
+        color: rgba(255, 255, 255, 0.5)
+    &:hover
+        background: rgba(0, 0, 0, 0.06)
+        color: rgba(0, 0, 0, 0.75)
+        +dark-mode
+            background: rgba(255, 255, 255, 0.08)
+            color: rgba(255, 255, 255, 0.8)
+    &.active
+        background: rgba(0, 0, 0, 0.08)
+        color: rgba(0, 0, 0, 0.9)
+        font-weight: 500
+        border-color: rgba(0, 0, 0, 0.08)
+        +dark-mode
+            background: rgba(255, 255, 255, 0.12)
+            color: rgba(255, 255, 255, 0.9)
+            border-color: rgba(255, 255, 255, 0.12)
+
+.tree-prefix
+    flex-shrink: 0
+    color: rgba(0, 0, 0, 0.35)
+    +dark-mode
+        color: rgba(255, 255, 255, 0.4)
+
+.block-label
+    flex: 1
+    min-width: 0
+    overflow: hidden
+    text-overflow: ellipsis
+    padding-right: 2px
+
+.resize-handle
+    position: absolute
+    top: 0
+    right: 0
+    width: 6px
+    height: 100%
+    cursor: col-resize
+    z-index: 1
+    &:hover
+        background: rgba(0, 0, 0, 0.08)
+        +dark-mode
+            background: rgba(255, 255, 255, 0.08)
+    &:active
+        background: rgba(0, 0, 0, 0.12)
+        +dark-mode
+            background: rgba(255, 255, 255, 0.12)
+</style>

--- a/src/components/tabs/TabBar.vue
+++ b/src/components/tabs/TabBar.vue
@@ -14,7 +14,6 @@
             TabItem,
             draggable,
         },
-
         data() {
             return {
                 isMac: window.heynote.platform.isMac,
@@ -31,7 +30,7 @@
                 "settings",
             ]),
             ...mapWritableState(useHeynoteStore, ["openTabs"]),
-            ...mapStores(useEditorCacheStore, useHeynoteStore),
+            ...mapStores(useEditorCacheStore, useHeynoteStore, useSettingsStore),
 
             tabs() {
                 return this.openTabs.map((path) => {
@@ -69,6 +68,10 @@
             showTabs() {
                 return this.settings.showTabs
             },
+
+            showDocumentListSidebar() {
+                return this.settings.showDocumentListSidebar === true
+            },
         },
 
         methods: {
@@ -80,6 +83,13 @@
 
             openBufferSelector() {
                 this.heynoteStore.openBufferSelector()
+            },
+
+            toggleDocumentListSidebar() {
+                this.settingsStore.updateSettings({
+                    showDocumentListSidebar: !this.settings.showDocumentListSidebar,
+                })
+                this.heynoteStore.focusEditor()
             },
 
             dragEnd(event) {
@@ -97,6 +107,16 @@
         <div class="main-menu-container">
             <button class="main-menu"
                 @click="onMainMenuClick"
+            ></button>
+        </div>
+        <div class="sidebar-toggle-container">
+            <button
+                type="button"
+                class="sidebar-toggle"
+                :class="{ active: showDocumentListSidebar }"
+                :title="showDocumentListSidebar ? 'Hide document list' : 'Show document list'"
+                tabindex="-1"
+                @click="toggleDocumentListSidebar"
             ></button>
         </div>
         <template v-if="showTabs">
@@ -131,11 +151,8 @@
                 ></button>
             </div>
         </template>
-        <div 
-            v-else
-            class="title"
-        >
-            {{ currentBufferName }}
+        <div v-else class="title-wrapper">
+            <div class="title">{{ currentBufferName }}</div>
         </div>
     </nav>
 </template>
@@ -235,7 +252,42 @@
                     background-color: #ccc
                     +dark-mode
                         background-color: #3a3a3a
+        .sidebar-toggle-container
+            app-region: none
+            display: flex
+            align-items: center
+            padding: 4px 6px
+            border-right: 1px solid #e6e6e6
+            +dark-mode
+                border-right: 1px solid #242424
+            .sidebar-toggle
+                width: 20px
+                height: 20px
+                border: none
+                background: none
+                border-radius: 3px
+                cursor: pointer
+                transition: background-color 250ms
+                background-image: url("@/assets/icons/document-list-light.svg")
+                background-repeat: no-repeat
+                background-position: center
+                background-size: 14px
+                +dark-mode
+                    background-image: url("@/assets/icons/document-list-dark.svg")
+                &:hover
+                    background-color: #ccc
+                    +dark-mode
+                        background-color: #3a3a3a
+                &.active
+                    background-color: #c5c5c5
+                    +dark-mode
+                        background-color: #3a3a3a
+                    box-shadow: var(--tab-bar-inset-shadow)
         
+        .title-wrapper
+            flex: 1
+            min-width: 0
+            position: relative
         .title
             pointer-events: none
             text-align: center

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -18,6 +18,7 @@ export const useHeynoteStore = defineStore("heynote", {
 
         currentEditor: null,
         currentBufferPath: null,
+        blockListVersion: 0,
         currentBufferName: null,
         currentLanguage: null,
         currentLanguageAuto: null,
@@ -174,6 +175,10 @@ export const useHeynoteStore = defineStore("heynote", {
             const recent = this.recentBufferPaths.filter((p) => p !== path)
             recent.unshift(path)
             this.recentBufferPaths = recent.slice(0, 100)
+        },
+
+        bumpBlockListVersion() {
+            this.blockListVersion++
         },
 
         openLanguageSelector() {

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -91,6 +91,8 @@ let initialSettings = {
     keyBindings: [],
     showTabs: true,
     showTabsInFullscreen: true,
+    showDocumentListSidebar: false,
+    documentListSidebarWidth: 200,
     cursorBlinkRate: 1000,
 }
 if (settingsData !== null) {


### PR DESCRIPTION
### Summary
Adds an optional left sidebar that lists open documents (buffers) and, when expanded, their blocks in a tree layout. It can be toggled from the tab bar and resized; the block list updates when the document content changes (e.g. Ctrl+Enter new block).

Closes #454

---

### Screenshots

| Expanded View | Sidebar Layout |
|:-------------:|:--------------:|
| <img src="https://github.com/user-attachments/assets/c58ab7e4-9f81-424e-a779-e082960c2dbb" width="250"/> | <img src="https://github.com/user-attachments/assets/12c3261a-f0da-43d4-b32a-1f31447b5610" width="250"/> |
| *Expanded with blocks* | *Sidebar layout* |

---

### Features

| Feature | Description |
|--------|-------------|
| **Toggle** | Button in the tab bar (left of the tabs) to show/hide the sidebar (Gedit/Ubuntu style). |
| **Document list** | Shows all open buffers; click a row to switch to that document. |
| **Expand/collapse** | Chevron (▼/▶) per document; when expanded and that document is active, its blocks are shown below in a tree. |
| **Tree style** | Blocks use `├──` / `└──` under the expanded document. |
| **Block navigation** | Click a block to move the cursor to the end of that block and focus the editor. |
| **Resizable** | Drag the right edge to resize (140–400px); width is persisted in settings. |
| **Live updates** | Block list refreshes on doc changes (e.g. new block with Ctrl+Enter) without switching buffer. |
| **Close** | Per-document close (×) in the sidebar. |

---

### How to use

1. Click the **document-list icon** in the tab bar to open the sidebar.
2. Click a **document row** to switch to that buffer.
3. Click the **chevron** to expand and see blocks.
4. Click a **block** to jump to it.
5. Drag the sidebar’s right edge to resize.

---

### Technical notes

| Area | Details |
|------|--------|
| **Component** | New: `DocumentListSidebar.vue` |
| **Icons** | New: `document-list-light.svg`, `document-list-dark.svg` |
| **Settings** | `showDocumentListSidebar`, `documentListSidebarWidth` (electron + webapp) |
| **Reactivity** | Sidebar block list driven by `blockListVersion` in the store, bumped on doc change via a CodeMirror `ViewPlugin` when the current buffer’s document changes. |
| **Persistence** | Sidebar width and visibility stored in user settings. |

---
