### PR TITLE
Persist the search query between different buffers, and between restarts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 Here are the most notable changes in each release. For a more detailed list of changes, see the [Github Releases page](https://github.com/heyman/heynote/releases).
 
+## Not yet released
+
+- Persist the search query between different buffers, and between restarts
+
+
 ## 2.8.2
 
 - Fix issue with broken images after changing the buffer files path

--- a/src/editor/search/SearchPanel.vue
+++ b/src/editor/search/SearchPanel.vue
@@ -41,10 +41,14 @@
 
         mounted() {
             if (this.settingsStore.settings.searchSettings) {
-                this.caseSensitive = this.settingsStore.settings.searchSettings.caseSensitive
-                this.regexp = this.settingsStore.settings.searchSettings.regexp
-                this.wholeWord = this.settingsStore.settings.searchSettings.wholeWord
-                this.onlyCurrentBlock = this.settingsStore.settings.searchSettings.onlyCurrentBlock
+                const searchSettings = this.settingsStore.settings.searchSettings
+                if (searchSettings.query !== undefined) {
+                    this.queryStr = searchSettings.query
+                }
+                this.caseSensitive = searchSettings.caseSensitive
+                this.regexp = searchSettings.regexp
+                this.wholeWord = searchSettings.wholeWord
+                this.onlyCurrentBlock = searchSettings.onlyCurrentBlock
             }
 
             this.$nextTick(() => {
@@ -77,9 +81,24 @@
             searchParams() {
                 this.search()
             },
+
+            queryStr() {
+                this.persistSearchSettings({
+                    query: this.queryStr,
+                })
+            },
         },
 
         methods: {
+            persistSearchSettings(settings) {
+                this.settingsStore.updateSettings({
+                    searchSettings: {
+                        ...(this.settingsStore.settings.searchSettings || {}),
+                        ...settings,
+                    },
+                })
+            },
+
             search() {
                 let query = new SearchQuery({
                     search: this.queryStr,
@@ -140,13 +159,12 @@
                 if (event.detail > 0) {
                     this.$refs.input.focus()
                 }
-                this.settingsStore.updateSettings({
-                    searchSettings: {
-                        onlyCurrentBlock: this.onlyCurrentBlock,
-                        caseSensitive: this.caseSensitive,
-                        regexp: this.regexp,
-                        wholeWord: this.wholeWord,
-                    },
+                this.persistSearchSettings({
+                    query: this.queryStr,
+                    onlyCurrentBlock: this.onlyCurrentBlock,
+                    caseSensitive: this.caseSensitive,
+                    regexp: this.regexp,
+                    wholeWord: this.wholeWord,
                 })
                 this.view.dispatch({
                     annotations: [heynoteEvent.of(SEARCH_SETTINGS_UPDATED)],//, Transaction.addToHistory.of(false)],

--- a/tests/playwright/search.spec.js
+++ b/tests/playwright/search.spec.js
@@ -190,6 +190,9 @@ test("regular expressions setting", async ({ page }) => {
 test("search settings persistence", async ({ page }) => {
     // Open search panel
     await page.locator("body").press(heynotePage.agnosticKey("Mod+f"))
+
+    // Set a search query
+    await page.locator(".search-panel input[main-field]").fill("persisted query")
     
     // Toggle some settings
     await page.locator(".search-panel .input-toggle.case-sensitive").click()
@@ -208,10 +211,30 @@ test("search settings persistence", async ({ page }) => {
     // Open search panel again
     await page.locator("body").press(heynotePage.agnosticKey("Mod+f"))
     
-    // Check that settings are preserved
+    // Check that settings and query are preserved
+    await expect(page.locator(".search-panel input[main-field]")).toHaveValue("persisted query")
     await expect(page.locator(".search-panel .input-toggle.case-sensitive")).toHaveClass(/active/)
     await expect(page.locator(".search-panel .input-toggle.whole-words")).toHaveClass(/active/)
     await expect(page.locator(".search-panel .input-toggle.block")).not.toHaveClass(/active/)
+})
+
+test("search query persists between editor instances", async ({ page }) => {
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+f"))
+    await page.locator(".search-panel input[main-field]").fill("shared search")
+    await page.locator("body").press("Escape")
+
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+n"))
+    await page.locator("body").pressSequentially("Second Buffer")
+    await page.locator("body").press("Enter")
+    await page.waitForTimeout(100)
+
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+f"))
+    await expect(page.locator(".search-panel input[main-field]")).toHaveValue("shared search")
+    await page.locator("body").press("Escape")
+
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+1"))
+    await page.locator("body").press(heynotePage.agnosticKey("Mod+f"))
+    await expect(page.locator(".search-panel input[main-field]")).toHaveValue("shared search")
 })
 
 test("combined search settings", async ({ page }) => {


### PR DESCRIPTION
Store search query in searchSettings so that it's persisted between different Editor instances and between restarts.

Fixes #468 