### PR TITLE
Add global search across all buffers

### DIFF
--- a/assets/icons/files-dark.svg
+++ b/assets/icons/files-dark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <g id="SVGRepo_iconCarrier">
+        <path d="M583.333,0L283.333,0L233.333,50L233.333,200L83.333,200L33.333,250L33.333,752.333L83.333,800L485.667,800L533.333,752.333L533.333,600L690,600L733.333,552.333L733.333,150L583.333,0ZM583.333,70.667L662.667,150L583.333,150L583.333,70.667ZM483.333,750L83.333,750L83.333,250L233.333,250L233.333,552.333L283.333,600L483.333,600L483.333,750ZM683.333,550L283.333,550L283.333,50L533.333,50L533.333,200L683.333,200L683.333,550Z" style="fill:rgb(196,196,196);fill-rule:nonzero;stroke:rgb(194,196,200);stroke-width:1px;"/>
+    </g>
+</svg>

--- a/assets/icons/files-light.svg
+++ b/assets/icons/files-light.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#686868" stroke="#686868">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M17.5 0h-9L7 1.5V6H2.5L1 7.5v15.07L2.5 24h12.07L16 22.57V18h4.7l1.3-1.43V4.5L17.5 0zm0 2.12l2.38 2.38H17.5V2.12zm-3 20.38h-12v-15H7v9.07L8.5 18h6v4.5zm6-6h-12v-15H16V6h4.5v10.5z"/>
+</g>
+</svg>

--- a/assets/icons/search-dark.svg
+++ b/assets/icons/search-dark.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill="#c4c4c4" fill-rule="evenodd" d="M4 9a5 5 0 1110 0A5 5 0 014 9zm5-7a7 7 0 104.2 12.6.999.999 0 00.093.107l3 3a1 1 0 001.414-1.414l-3-3a.999.999 0 00-.107-.093A7 7 0 009 2z"/> </g>
+</svg>

--- a/assets/icons/search-light.svg
+++ b/assets/icons/search-light.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill="#686868" fill-rule="evenodd" d="M4 9a5 5 0 1110 0A5 5 0 014 9zm5-7a7 7 0 104.2 12.6.999.999 0 00.093.107l3 3a1 1 0 001.414-1.414l-3-3a.999.999 0 00-.107-.093A7 7 0 009 2z"/> </g>
+</svg>

--- a/electron/config.js
+++ b/electron/config.js
@@ -48,7 +48,7 @@ const schema = {
             "showFoldGutter": {type: "boolean", default:true},
             "showTabs": {type: "boolean", default: true},
             "showTabsInFullscreen": {type: "boolean", default: true},
-            "showLeftPanel": {type: "boolean", default: false},
+            "showLeftPanel": {type: "boolean", default: true},
             "leftPanelWidth": {type: "integer", default: 250},
             "bufferTreeOpenFolders": {
                 type: "array",
@@ -134,7 +134,7 @@ const defaults = {
         keyBindings: [],
         showLineNumberGutter: true,
         showFoldGutter: true,
-        showLeftPanel: false,
+        showLeftPanel: true,
         leftPanelWidth: 250,
         bufferTreeOpenFolders: [],
         autoUpdate: true,

--- a/electron/config.js
+++ b/electron/config.js
@@ -49,7 +49,7 @@ const schema = {
             "showTabs": {type: "boolean", default: true},
             "showTabsInFullscreen": {type: "boolean", default: true},
             "showLeftPanel": {type: "boolean", default: false},
-            "leftPanelWidth": {type: "integer", default: 220},
+            "leftPanelWidth": {type: "integer", default: 250},
             "bufferTreeOpenFolders": {
                 type: "array",
                 items: {type: "string"},
@@ -135,7 +135,7 @@ const defaults = {
         showLineNumberGutter: true,
         showFoldGutter: true,
         showLeftPanel: false,
-        leftPanelWidth: 220,
+        leftPanelWidth: 250,
         bufferTreeOpenFolders: [],
         autoUpdate: true,
         allowBetaVersions: false,

--- a/electron/config.js
+++ b/electron/config.js
@@ -94,6 +94,14 @@ const schema = {
                     regexp: {type: "boolean"},
                 },
             },
+            "librarySearchSettings": {
+                type: "object",
+                properties: {
+                    caseSensitive: {type: "boolean"},
+                    wholeWord: {type: "boolean"},
+                    regexp: {type: "boolean"},
+                },
+            },
         },
     },
 
@@ -150,6 +158,11 @@ const defaults = {
         tabSize: 4,
         searchSettings: {
             onlyCurrentBlock: true,
+            caseSensitive: false,
+            wholeWord: false,
+            regexp: false,
+        },
+        librarySearchSettings: {
             caseSensitive: false,
             wholeWord: false,
             regexp: false,

--- a/electron/main/file-library.js
+++ b/electron/main/file-library.js
@@ -65,7 +65,9 @@ export class FileLibrary {
         }
 
         // garbage collect stale images
-        this.removeUnreferencedImages()
+        this.removeUnreferencedImages().catch((err) => {
+            console.error(err)
+        })
     }
 
     async exists(path) {
@@ -277,6 +279,9 @@ export class FileLibrary {
         }
         
         const jp = jetpack.cwd(this.imagesBasePath)
+        if (!jetpack.exists(this.imagesBasePath)) {
+            return
+        }
         const files = await jp.findAsync("", {
             matching: "*",
             recursive: false,

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -7,6 +7,7 @@ import {
     WINDOW_CLOSE_EVENT, WINDOW_FULLSCREEN_STATE, WINDOW_FOCUS_STATE, SETTINGS_CHANGE_EVENT,
     TITLE_BAR_BG_LIGHT, TITLE_BAR_BG_LIGHT_BLURRED, TITLE_BAR_BG_DARK, TITLE_BAR_BG_DARK_BLURRED,
     SCRATCH_FILE_NAME, SAVE_TABS_STATE, LOAD_TABS_STATE, CONTEXT_MENU_CLOSED, GET_SYSTEM_LOCALE,
+    LIBRARY_SEARCH_START, LIBRARY_SEARCH_CANCEL, LIBRARY_SEARCH_MATCH, LIBRARY_SEARCH_DONE, LIBRARY_SEARCH_ERROR,
 } from '@/src/common/constants'
 
 import { menu, getTrayMenu, getEditorContextMenu, getTabContextMenu, getBufferTreeContextMenu, getBufferTreeDirectoryContextMenu, getBufferTreeBackgroundContextMenu, getSpellcheckingContextMenu } from './menu'
@@ -22,6 +23,7 @@ import {
     NOTES_DIR_NAME 
 } from './file-library';
 import { registerProtocol, registerProtocolBeforeAppReady } from "./protocol.js"
+import { startLibrarySearch } from "./ripgrep.js"
 
 
 // The built directory structure
@@ -62,6 +64,7 @@ Menu.setApplicationMenu(menu)
 
 export let win: BrowserWindow | null = null
 let fileLibrary: FileLibrary | null = null
+let currentLibrarySearch: any = null
 let tray: Tray | null = null;
 let initErrors: string[] = []
 // Here, you can also use other preload
@@ -520,6 +523,44 @@ ipcMain.handle("showSpellcheckingContextMenu", (event) => {
     getSpellcheckingContextMenu(win).popup({window: win})
 })
 
+function stopCurrentLibrarySearch() {
+    if (currentLibrarySearch) {
+        currentLibrarySearch.kill()
+        currentLibrarySearch = null
+    }
+}
+
+ipcMain.handle(LIBRARY_SEARCH_START, (event, options) => {
+    stopCurrentLibrarySearch()
+    if (!fileLibrary) {
+        throw new Error("File library is not initialized")
+    }
+
+    let controller: any = null
+    controller = startLibrarySearch(fileLibrary, options, (payload: any) => {
+        if (payload.type === "match") {
+            event.sender.send(LIBRARY_SEARCH_MATCH, payload)
+        } else if (payload.type === "done") {
+            if (currentLibrarySearch === controller) {
+                currentLibrarySearch = null
+            }
+            event.sender.send(LIBRARY_SEARCH_DONE, payload)
+        } else if (payload.type === "error") {
+            if (currentLibrarySearch === controller) {
+                currentLibrarySearch = null
+            }
+            event.sender.send(LIBRARY_SEARCH_ERROR, payload)
+        }
+    })
+    currentLibrarySearch = controller
+    return { ok: true }
+})
+
+ipcMain.handle(LIBRARY_SEARCH_CANCEL, () => {
+    stopCurrentLibrarySearch()
+    return { ok: true }
+})
+
 // Initialize note/file library
 async function initFileLibrary(win) {
     await migrateBufferFileToLibrary(app)
@@ -576,6 +617,7 @@ ipcMain.handle('settings:set', async (event, settings) => {
         registerAlwaysOnTop()
     }
     if (bufferPathChanged) {
+        stopCurrentLibrarySearch()
         console.log("bufferPath changed, closing existing file library")
         fileLibrary.close()
         console.log("initializing new file library")

--- a/electron/main/ripgrep.js
+++ b/electron/main/ripgrep.js
@@ -3,7 +3,8 @@ import { spawn } from "node:child_process"
 import { once } from "node:events"
 import readline from "node:readline"
 
-import { IMAGE_REGEX_RIPGREP, IMAGE_REGEX } from "@/src/common/constants.js"
+import { IMAGE_REGEX_RIPGREP } from "@/src/common/constants.js"
+import { normalizeLibrarySearchMatch } from "@/src/common/library-search-match.js"
 import { parseImagesFromString } from "@/src/editor/image/image-parsing.js"
 
 
@@ -134,9 +135,7 @@ export function startLibrarySearch(library, options, onEvent) {
         }
         const matchData = data.data
         const matchedLine = (matchData.lines?.text || "").replace(/\r?\n$/, "")
-        emit({
-            type: "match",
-            buffer: normalizeRipgrepPath(matchData.path?.text),
+        const normalizedMatch = normalizeLibrarySearchMatch({
             line: matchedLine,
             lineNumber: matchData.line_number,
             submatches: (matchData.submatches || []).map((submatch) => ({
@@ -144,6 +143,14 @@ export function startLibrarySearch(library, options, onEvent) {
                 end: utf8ByteOffsetToStringIndex(matchedLine, submatch.end),
                 text: submatch.match?.text || "",
             })),
+        })
+        if (!normalizedMatch) {
+            return
+        }
+        emit({
+            type: "match",
+            buffer: normalizeRipgrepPath(matchData.path?.text),
+            ...normalizedMatch,
         })
     })
     rg.stderr.on("data", (data) => {

--- a/electron/main/ripgrep.js
+++ b/electron/main/ripgrep.js
@@ -96,7 +96,9 @@ export function startLibrarySearch(library, options, onEvent) {
         "--glob",
         "!.images/**",
     ]
-    if (!options.regexp) {
+    if (options.regexp) {
+        args.push("--pcre2")
+    } else {
         args.push("--fixed-strings")
     }
     if (!options.caseSensitive) {

--- a/electron/main/ripgrep.js
+++ b/electron/main/ripgrep.js
@@ -48,6 +48,139 @@ export async function runRipgrep(args, cwd, onLine) {
     return { code, signal, stdout, stderr }
 }
 
+function normalizeRipgrepPath(path) {
+    if (!path) {
+        return ""
+    }
+    if (path.startsWith("./") || path.startsWith(".\\")) {
+        return path.substring(2)
+    }
+    return path
+}
+
+function utf8ByteOffsetToStringIndex(text, targetOffset) {
+    if (targetOffset <= 0) {
+        return 0
+    }
+    let byteOffset = 0
+    let stringIndex = 0
+    for (const codePoint of text) {
+        if (byteOffset >= targetOffset) {
+            return stringIndex
+        }
+        byteOffset += Buffer.byteLength(codePoint)
+        stringIndex += codePoint.length
+        if (byteOffset >= targetOffset) {
+            return stringIndex
+        }
+    }
+    return text.length
+}
+
+export function startLibrarySearch(library, options, onEvent) {
+    if (!library?.basePath) {
+        throw Error("library.basePath not set, is library initialized?")
+    }
+    const query = options?.query || ""
+    if (query.length <= 2) {
+        throw Error("Search query must be longer than 2 characters")
+    }
+
+    const args = [
+        "--json",
+        "--fixed-strings",
+        "--line-number",
+        "--column",
+        "--glob",
+        "*.txt",
+        "--glob",
+        "!.images/**",
+    ]
+    if (!options.caseSensitive) {
+        args.push("--ignore-case")
+    }
+    if (options.wholeWord) {
+        args.push("--word-regexp")
+    }
+    args.push("--", query, ".")
+
+    let stderr = ""
+    let killed = false
+    const rg = spawn(rgDiskPath, args, { stdio: ["ignore", "pipe", "pipe"], cwd: library.basePath })
+    rg.stdout.setEncoding("utf8")
+    rg.stderr.setEncoding("utf8")
+
+    const emit = (payload) => {
+        onEvent?.({
+            searchId: options.searchId,
+            ...payload,
+        })
+    }
+
+    const rl = readline.createInterface({ input: rg.stdout })
+    rl.on("line", (line) => {
+        if (!line) {
+            return
+        }
+        let data
+        try {
+            data = JSON.parse(line)
+        } catch (error) {
+            emit({ type: "error", message: error.message })
+            return
+        }
+        if (data.type !== "match") {
+            return
+        }
+        const matchData = data.data
+        const matchedLine = (matchData.lines?.text || "").replace(/\r?\n$/, "")
+        emit({
+            type: "match",
+            buffer: normalizeRipgrepPath(matchData.path?.text),
+            line: matchedLine,
+            lineNumber: matchData.line_number,
+            submatches: (matchData.submatches || []).map((submatch) => ({
+                start: utf8ByteOffsetToStringIndex(matchedLine, submatch.start),
+                end: utf8ByteOffsetToStringIndex(matchedLine, submatch.end),
+                text: submatch.match?.text || "",
+            })),
+        })
+    })
+    rg.stderr.on("data", (data) => {
+        stderr += data
+    })
+    rg.on("error", (error) => {
+        emit({ type: "error", message: error.message })
+    })
+    rg.on("close", (code, signal) => {
+        rl.close()
+        if (killed) {
+            emit({ type: "done", cancelled: true })
+            return
+        }
+        // ripgrep exits with code 1 if there were no hits
+        if (code !== 0 && code !== 1) {
+            emit({
+                type: "error",
+                code,
+                signal,
+                message: stderr || `ripgrep exited with code ${code}`,
+            })
+            return
+        }
+        emit({ type: "done" })
+    })
+
+    return {
+        kill() {
+            killed = true
+            if (!rg.killed) {
+                rg.kill()
+            }
+        },
+    }
+}
+
 
 /*
 export async function searchLibrary(library, query) {
@@ -96,4 +229,3 @@ export async function getImgReferences(basePath) {
     const result = await runRipgrep(["--json", IMAGE_REGEX_RIPGREP], basePath, onLine)
     return imageFiles
 }
-

--- a/electron/main/ripgrep.js
+++ b/electron/main/ripgrep.js
@@ -89,7 +89,6 @@ export function startLibrarySearch(library, options, onEvent) {
 
     const args = [
         "--json",
-        "--fixed-strings",
         "--line-number",
         "--column",
         "--glob",
@@ -97,6 +96,9 @@ export function startLibrarySearch(library, options, onEvent) {
         "--glob",
         "!.images/**",
     ]
+    if (!options.regexp) {
+        args.push("--fixed-strings")
+    }
     if (!options.caseSensitive) {
         args.push("--ignore-case")
     }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -17,6 +17,12 @@ export const LOAD_TABS_STATE = "load-tabs-state"
 export const CONTEXT_MENU_CLOSED = "context-menu-closed"
 export const GET_SYSTEM_LOCALE = "getSystemLocale"
 
+export const LIBRARY_SEARCH_START = "library-search:start"
+export const LIBRARY_SEARCH_CANCEL = "library-search:cancel"
+export const LIBRARY_SEARCH_MATCH = "library-search:match"
+export const LIBRARY_SEARCH_DONE = "library-search:done"
+export const LIBRARY_SEARCH_ERROR = "library-search:error"
+
 export const UPDATE_AVAILABLE_EVENT = "update-available"
 export const UPDATE_NOT_AVAILABLE_EVENT = "update-not-available"
 export const UPDATE_DOWNLOADED = "update-downloaded"

--- a/src/common/library-search-match.js
+++ b/src/common/library-search-match.js
@@ -1,0 +1,92 @@
+const HEYNOTE_TAG_REGEX = /<∞.*?∞>/g
+const BLOCK_DELIMITER_LINE_REGEX = /^∞∞∞[^\r\n]*$/
+const METADATA_KEYS = new Set([
+    "formatVersion",
+    "name",
+    "tags",
+    "cursors",
+    "foldedRanges",
+])
+
+function isMetadataLine(line, lineNumber) {
+    if (lineNumber !== 1) {
+        return false
+    }
+    const trimmed = line.trim()
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+        return false
+    }
+    try {
+        const metadata = JSON.parse(trimmed)
+        return metadata && typeof metadata === "object" &&
+            Object.keys(metadata).some((key) => METADATA_KEYS.has(key))
+    } catch {
+        return false
+    }
+}
+
+function syntaxRangesForLine(line, lineNumber) {
+    if (isMetadataLine(line, lineNumber) || BLOCK_DELIMITER_LINE_REGEX.test(line)) {
+        return [{ start: 0, end: line.length }]
+    }
+
+    const ranges = []
+    for (const match of line.matchAll(HEYNOTE_TAG_REGEX)) {
+        ranges.push({
+            start: match.index,
+            end: match.index + match[0].length,
+        })
+    }
+    return ranges
+}
+
+function overlapsAnyRange(item, ranges) {
+    return ranges.some((range) => item.start < range.end && range.start < item.end)
+}
+
+function rawIndexToDisplayIndex(rawIndex, ranges) {
+    let displayIndex = rawIndex
+    for (const range of ranges) {
+        if (range.end <= rawIndex) {
+            displayIndex -= range.end - range.start
+        }
+    }
+    return displayIndex
+}
+
+function removeRanges(line, ranges) {
+    if (ranges.length === 0) {
+        return line
+    }
+    let cursor = 0
+    let result = ""
+    for (const range of ranges) {
+        result += line.slice(cursor, range.start)
+        cursor = range.end
+    }
+    result += line.slice(cursor)
+    return result
+}
+
+export function normalizeLibrarySearchMatch({ line, lineNumber, submatches }) {
+    const syntaxRanges = syntaxRangesForLine(line, lineNumber)
+    const visibleSubmatches = (submatches || []).filter((submatch) => !overlapsAnyRange(submatch, syntaxRanges))
+    if (visibleSubmatches.length === 0) {
+        return null
+    }
+
+    const displayLine = removeRanges(line, syntaxRanges)
+    const displaySubmatches = visibleSubmatches.map((submatch) => ({
+        start: rawIndexToDisplayIndex(submatch.start, syntaxRanges),
+        end: rawIndexToDisplayIndex(submatch.end, syntaxRanges),
+        text: submatch.text,
+    }))
+
+    return {
+        line,
+        displayLine,
+        lineNumber,
+        submatches: visibleSubmatches,
+        displaySubmatches,
+    }
+}

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -221,7 +221,10 @@
                     return
                 }
 
-                runScopeHandlers(editor.view, event, "global")
+                if (runScopeHandlers(editor.view, event, "global")) {
+                    event.preventDefault()
+                    event.stopPropagation()
+                }
             },
 
             onSelectLanguage(language) {

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,6 +1,7 @@
 <script>
     import { toRaw } from 'vue'
     import { mapState, mapActions } from 'pinia'
+    import { runScopeHandlers } from "@codemirror/view"
 
     import { mapWritableState, mapStores } from 'pinia'
     import { useHeynoteStore } from "../stores/heynote-store"
@@ -47,6 +48,7 @@
 
         mounted() {
             this.settingsStore.setUp()
+            window.addEventListener("keydown", this.onGlobalKeydown)
             
             window.heynote.mainProcess.on(OPEN_SETTINGS_EVENT, () => {
                 this.showSettings = true
@@ -104,6 +106,7 @@
         },
 
         beforeUnmount() {
+            window.removeEventListener("keydown", this.onGlobalKeydown)
             this.settingsStore.tearDown()
         },
 
@@ -202,6 +205,23 @@
             closeSettings() {
                 this.showSettings = false
                 this.focusEditor()
+            },
+
+            onGlobalKeydown(event) {
+                if (this.showSettings || event.defaultPrevented) {
+                    return
+                }
+
+                const editor = toRaw(this.heynoteStore.currentEditor)
+                if (!editor?.view) {
+                    return
+                }
+
+                if (event.target instanceof Node && editor.view.contentDOM.contains(event.target)) {
+                    return
+                }
+
+                runScopeHandlers(editor.view, event, "global")
             },
 
             onSelectLanguage(language) {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1,7 +1,7 @@
 <script>
     import { syntaxTree } from "@codemirror/language"
     import { toRaw } from 'vue';
-    import { mapState, mapWritableState, mapStores } from 'pinia'
+    import { mapActions, mapState, mapWritableState, mapStores } from 'pinia'
     import { useHeynoteStore } from "../stores/heynote-store.js"
     import { useEditorCacheStore } from "../stores/editor-cache"
     import { REDO_EVENT, WINDOW_CLOSE_EVENT, DELETE_BLOCK_EVENT, UNDO_EVENT, SELECT_ALL_EVENT } from '@/src/common/constants';
@@ -133,16 +133,26 @@
         },
 
         methods: {
+            ...mapActions(useHeynoteStore, [
+                "consumeFocusEditorOnBufferOpen",
+            ]),
+
             loadBuffer(path) {
                 //console.log("loadBuffer", path)
                 if (this.editor) {
                     this.editor.hide()
                 }
 
-                const [editor, created] = this.editorCacheStore.getOrCreateEditor(path)
+                const focusEditor = this.consumeFocusEditorOnBufferOpen()
+                const [editor, created] = this.editorCacheStore.getOrCreateEditor(path, {
+                    focus: focusEditor,
+                })
                 this.editor = editor
                 if (!created) {
                     toRaw(editor).show()
+                    if (focusEditor) {
+                        toRaw(editor).focus()
+                    }
                 }
 
                 this.currentEditor = toRaw(this.editor)

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -133,12 +133,10 @@
             <button
                 @click="() => currentLeftPanel='buffer-tree'"
                 :class="{selected:currentLeftPanel=='buffer-tree'}"
-                tabindex="-1"
             ><i class="icon buffers"></i>Buffers</button>
             <button
                 @click="() => currentLeftPanel='search'"
                 :class="{selected:currentLeftPanel=='search'}"
-                tabindex="-1"
             ><i class="icon search"></i>Search</button>
         </div>
         <div
@@ -198,6 +196,13 @@
                 border-top: 1px solid transparent
                 +dark-mode
                     color: rgba(255,255,255, 0.6)
+                &:focus
+                    outline: none
+                &:focus-visible
+                    box-shadow: inset 0 0 0 2px #388c62
+                    z-index: 1
+                    +dark-mode
+                        box-shadow: inset 0 0 0 2px #48b57e
                 &:last-child  
                     margin-right: 0
                 &:hover

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -173,17 +173,20 @@
             //justify-content: center
             width: 100%
             border-top: 1px solid var(--tab-bar-border-bottom-color)
+            +dark-mode
+                background: #282828
             button
                 background: none
                 border: none
                 //border-radius: 3px 3px 0 0
-                padding: 5px 8px
+                padding: 5px 8px 6px 8px
                 margin-right: 0px
                 color: rgba(0,0,0, 0.6)
                 cursor: pointer
                 font-size: 12px
                 position: relative
                 top: -1px
+                border-top: 1px solid transparent
                 +dark-mode
                     color: rgba(255,255,255, 0.6)
                 &:last-child  

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -69,6 +69,14 @@
             },
         },
 
+        watch: {
+            currentLeftPanel(newPanel, oldPanel) {
+                if (oldPanel === "search" && newPanel !== "search") {
+                    this.heynoteStore.hideLeftPanelOnLibrarySearchEscape = false
+                }
+            },
+        },
+
         methods: {
             onResizerMouseDown(event) {
                 if (event.button !== 0) {

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -1,5 +1,5 @@
 <script>
-    import { mapState, mapStores } from "pinia"
+    import { mapState, mapStores, mapWritableState } from "pinia"
 
     import { TITLE_BAR_BG_LIGHT, TITLE_BAR_BG_DARK, TITLE_BAR_BG_LIGHT_BLURRED, TITLE_BAR_BG_DARK_BLURRED } from "@/src/common/constants"
     import { useHeynoteStore } from "@/src/stores/heynote-store"
@@ -7,11 +7,14 @@
 
     import MainMenuButton from "./tabs/MainMenuButton.vue"
     import BufferTree from "./buffer-tree/BufferTree.vue"
+    import LibrarySearch from "./library-search/LibrarySearch.vue"
+
 
     export default {
         components: {
             MainMenuButton,
             BufferTree,
+            LibrarySearch,
         },
 
         data() {
@@ -35,6 +38,9 @@
         computed: {
             ...mapState(useHeynoteStore, [
                 "isFocused",
+            ]),
+            ...mapWritableState(useHeynoteStore, [
+                "currentLeftPanel",
             ]),
             ...mapState(useSettingsStore, [
                 "theme",
@@ -112,7 +118,20 @@
             <MainMenuButton />
         </div>
         <div class="left-panel-content">
-            <BufferTree />
+            <BufferTree v-if="currentLeftPanel == 'buffer-tree'" />
+            <LibrarySearch v-if="currentLeftPanel == 'search'" />
+        </div>
+        <div class="left-panel-tab-buttons">
+            <button
+                @click="() => currentLeftPanel='buffer-tree'"
+                :class="{selected:currentLeftPanel=='buffer-tree'}"
+                tabindex="-1"
+            >Buffers</button>
+            <button
+                @click="() => currentLeftPanel='search'"
+                :class="{selected:currentLeftPanel=='search'}"
+                tabindex="-1"
+            >Search</button>
         </div>
         <div
             :class="resizerClass"
@@ -139,11 +158,44 @@
             height: var(--tab-bar-height)
             flex-shrink: 0
             app-region: drag
+            display: flex
 
         .left-panel-content
             flex-grow: 1
             min-height: 0
             //border-right: 1px solid var(--tab-bar-border-bottom-color)
+
+        .left-panel-tab-buttons
+            app-region: none
+            padding: 0px
+            display: flex
+            align-items: center
+            //justify-content: center
+            width: 100%
+            border-top: 1px solid var(--tab-bar-border-bottom-color)
+            button
+                background: none
+                border: none
+                //border-radius: 3px 3px 0 0
+                padding: 5px 8px
+                margin-right: 0px
+                color: rgba(0,0,0, 0.6)
+                cursor: pointer
+                font-size: 12px
+                position: relative
+                top: -1px
+                +dark-mode
+                    color: rgba(255,255,255, 0.6)
+                &:last-child  
+                    margin-right: 0
+                &:hover
+                    background: rgba(0,0,0, 0.08)
+                    +dark-mode
+                        background: rgba(255,255,255, 0.08)
+                &.selected
+                    border-top: 1px solid rgba(0,0,0, 0.7)
+                    +dark-mode
+                        border-top: 1px solid rgba(255,255,255, 0.8)
         
         .resizer
             position: absolute

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -126,12 +126,12 @@
                 @click="() => currentLeftPanel='buffer-tree'"
                 :class="{selected:currentLeftPanel=='buffer-tree'}"
                 tabindex="-1"
-            >Buffers</button>
+            ><i class="icon buffers"></i>Buffers</button>
             <button
                 @click="() => currentLeftPanel='search'"
                 :class="{selected:currentLeftPanel=='search'}"
                 tabindex="-1"
-            >Search</button>
+            ><i class="icon search"></i>Search</button>
         </div>
         <div
             :class="resizerClass"
@@ -176,6 +176,7 @@
             +dark-mode
                 background: #282828
             button
+                width: 50%
                 background: none
                 border: none
                 //border-radius: 3px 3px 0 0
@@ -192,13 +193,33 @@
                 &:last-child  
                     margin-right: 0
                 &:hover
-                    background: rgba(0,0,0, 0.08)
+                    background-color: rgba(0,0,0, 0.08)
                     +dark-mode
-                        background: rgba(255,255,255, 0.08)
+                        background-color: rgba(255,255,255, 0.08)
                 &.selected
                     border-top: 1px solid rgba(0,0,0, 0.7)
                     +dark-mode
                         border-top: 1px solid rgba(255,255,255, 0.8)
+                .icon
+                    display: inline-block
+                    width: 12px
+                    height: 12px
+                    background-size: 100%
+                    background-repeat: no-repeat
+                    margin-right: 5px
+                    position: relative
+                    top: 1px
+                    &.buffers
+                        background-image: url('@/assets/icons/files-light.svg')
+                        +dark-mode
+                            background-image: url('@/assets/icons/files-dark.svg')
+                    &.search
+                        background-image: url('@/assets/icons/search-light.svg')
+                        width: 13px
+                        height: 13px
+                        top: 2px
+                        +dark-mode
+                            background-image: url('@/assets/icons/search-dark.svg')
         
         .resizer
             position: absolute

--- a/src/components/buffer-tree/BufferTree.vue
+++ b/src/components/buffer-tree/BufferTree.vue
@@ -55,6 +55,7 @@
                 backgroundNewFolderPosition: "top",
                 draggingBufferPath: null,
                 dragOverFolderPath: null,
+                selectedItemKey: null,
             }
         },
 
@@ -65,6 +66,9 @@
             ])
             this.syncFolderOpenState()
             this.$nextTick(() => this.scrollActiveBufferIntoView())
+            if (this.bufferTreeFocusRequestId > 0) {
+                this.$nextTick(() => this.focusTree())
+            }
             window._heynote_buffer_tree = this
             window.heynote.mainProcess.on("bufferTree:createFolder", this.onCreateFolderRequested)
         },
@@ -87,7 +91,11 @@
             currentBufferPath() {
                 this.openCurrentPathFolders()
                 this.persistFolderOpenState()
+                this.selectCurrentBuffer()
                 this.$nextTick(() => this.scrollActiveBufferIntoView())
+            },
+            bufferTreeFocusRequestId() {
+                this.$nextTick(() => this.focusTree())
             },
         },
 
@@ -95,6 +103,7 @@
             ...mapState(useHeynoteStore, [
                 "buffers",
                 "currentBufferPath",
+                "bufferTreeFocusRequestId",
             ]),
 
             visibleItems() {
@@ -176,6 +185,10 @@
                 walk(this.buildTree(), 0, "")
                 return rows
             },
+
+            selectableItems() {
+                return this.visibleItems.filter((item) => this.isSelectableItem(item))
+            },
         },
 
         methods: {
@@ -190,6 +203,94 @@
             async refreshDirectoryList() {
                 const directories = await window.heynote.buffer.getDirectoryList()
                 this.directoryPaths = directories.filter((path) => !hasHiddenDirectorySegment(path))
+            },
+
+            isSelectableItem(item) {
+                return item?.type === "folder" || item?.type === "buffer"
+            },
+
+            itemKey(item) {
+                return item ? `${item.type}:${item.path}` : null
+            },
+
+            findSelectableItemByKey(key) {
+                return this.selectableItems.find((item) => this.itemKey(item) === key)
+            },
+
+            getSelectedItemIndex() {
+                this.ensureSelectedItem()
+                return this.selectableItems.findIndex((item) => this.itemKey(item) === this.selectedItemKey)
+            },
+
+            ensureSelectedItem() {
+                if (this.selectableItems.length === 0) {
+                    this.selectedItemKey = null
+                    return
+                }
+                if (this.findSelectableItemByKey(this.selectedItemKey)) {
+                    return
+                }
+                const activeBuffer = this.selectableItems.find((item) => item.type === "buffer" && item.path === this.currentBufferPath)
+                this.selectedItemKey = this.itemKey(activeBuffer || this.selectableItems[0])
+            },
+
+            selectCurrentBuffer() {
+                const activeBuffer = this.selectableItems.find((item) => item.type === "buffer" && item.path === this.currentBufferPath)
+                if (activeBuffer) {
+                    this.selectedItemKey = this.itemKey(activeBuffer)
+                }
+            },
+
+            setSelectedItem(item) {
+                this.selectedItemKey = this.itemKey(item)
+                this.$nextTick(() => this.scrollSelectedItemIntoView())
+            },
+
+            onTreeFocus() {
+                this.ensureSelectedItem()
+            },
+
+            focusTree() {
+                this.ensureSelectedItem()
+                this.$refs.container?.focus({ preventScroll: true })
+                this.$nextTick(() => this.scrollSelectedItemIntoView())
+            },
+
+            onTreeKeyDown(event) {
+                if (!["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft", "Enter"].includes(event.key)) {
+                    return
+                }
+                this.ensureSelectedItem()
+                const selectedIndex = this.getSelectedItemIndex()
+                const selectedItem = this.selectableItems[selectedIndex]
+                if (!selectedItem) {
+                    return
+                }
+
+                if (event.key === "ArrowDown") {
+                    event.preventDefault()
+                    this.setSelectedItem(this.selectableItems[Math.min(selectedIndex + 1, this.selectableItems.length - 1)])
+                } else if (event.key === "ArrowUp") {
+                    event.preventDefault()
+                    this.setSelectedItem(this.selectableItems[Math.max(selectedIndex - 1, 0)])
+                } else if (event.key === "ArrowRight") {
+                    event.preventDefault()
+                    if (selectedItem.type === "folder" && !selectedItem.open) {
+                        this.folderOpenState[selectedItem.path] = true
+                        this.persistFolderOpenState()
+                    }
+                } else if (event.key === "ArrowLeft") {
+                    event.preventDefault()
+                    if (selectedItem.type === "folder" && selectedItem.open) {
+                        this.folderOpenState[selectedItem.path] = false
+                        this.persistFolderOpenState()
+                    }
+                } else if (event.key === "Enter") {
+                    event.preventDefault()
+                    if (selectedItem.type === "buffer") {
+                        this.openBuffer(selectedItem.path)
+                    }
+                }
             },
 
             buildTree() {
@@ -286,6 +387,16 @@
             onFolderClick(path) {
                 this.folderOpenState[path] = !this.folderOpenState[path]
                 this.persistFolderOpenState()
+            },
+
+            onItemClick(item) {
+                this.setSelectedItem(item)
+                if (item.type === "folder") {
+                    this.onFolderClick(item.path)
+                } else {
+                    this.openBuffer(item.path)
+                    this.focusTree()
+                }
             },
 
             persistFolderOpenState() {
@@ -541,6 +652,17 @@
                 })
             },
 
+            scrollSelectedItemIntoView() {
+                const selectedItem = this.$el?.querySelector(".item.selected")
+                if (!selectedItem) {
+                    return
+                }
+                selectedItem.scrollIntoView({
+                    behavior: "auto",
+                    block: "nearest",
+                })
+            },
+
             indentGuides(level) {
                 return Array.from({ length: Math.max(0, level) }, (_, index) => index)
             },
@@ -552,7 +674,12 @@
 <template>
     <div
         :class="{ 'buffer-tree': true, 'root-drop-target': draggingBufferPath && dragOverFolderPath === '' }"
+        ref="container"
+        tabindex="0"
+        role="tree"
         @contextmenu="onBackgroundContextMenu"
+        @focus="onTreeFocus"
+        @keydown="onTreeKeyDown"
         @dragover="onTreeDragOver"
         @drop="onTreeDrop"
     >
@@ -574,11 +701,15 @@
                     open: item.open,
                     active: item.active,
                     scratch: item.scratch,
+                    selected: itemKey(item) === selectedItemKey,
                     'drop-target': item.type === 'folder' && dragOverFolderPath === item.path,
                 }"
                 :style="{ '--indent-level': item.level }"
                 :draggable="item.type === 'buffer' && !item.scratch"
-                @click="item.type === 'folder' ? onFolderClick(item.path) : openBuffer(item.path)"
+                role="treeitem"
+                :aria-expanded="item.type === 'folder' ? String(!!item.open) : undefined"
+                :aria-selected="itemKey(item) === selectedItemKey ? 'true' : 'false'"
+                @click="onItemClick(item)"
                 @contextmenu.stop="onItemContextMenu(item, $event)"
                 @dragstart="item.type === 'buffer' ? onBufferDragStart(item.path, $event) : null"
                 @dragend="item.type === 'buffer' ? onBufferDragEnd() : null"
@@ -606,6 +737,12 @@
         overflow-x: hidden
         padding: 4px 0
         box-sizing: border-box
+        &:focus
+            outline: none
+            .item.selected
+                outline: 1px solid #48b57e
+                outline-offset: -1px
+                z-index: 1
         &.root-drop-target
             background: rgba(0,0,0, 0.05)
             +dark-mode

--- a/src/components/buffer-tree/BufferTree.vue
+++ b/src/components/buffer-tree/BufferTree.vue
@@ -66,7 +66,7 @@
             ])
             this.syncFolderOpenState()
             this.$nextTick(() => this.scrollActiveBufferIntoView())
-            if (this.bufferTreeFocusRequestId > 0) {
+            if (this.consumeFocusBufferTreeOnMount()) {
                 this.$nextTick(() => this.focusTree())
             }
             window._heynote_buffer_tree = this
@@ -198,6 +198,7 @@
                 "createDirectory",
                 "moveBuffer",
                 "focusEditor",
+                "consumeFocusBufferTreeOnMount",
             ]),
 
             async refreshDirectoryList() {

--- a/src/components/buffer-tree/BufferTree.vue
+++ b/src/components/buffer-tree/BufferTree.vue
@@ -540,6 +540,10 @@
                     block: "nearest",
                 })
             },
+
+            indentGuides(level) {
+                return Array.from({ length: Math.max(0, level) }, (_, index) => index)
+            },
         },
 
     }
@@ -556,7 +560,8 @@
             <NewFolderItem
                 v-if="item.type === 'new-folder'"
                 :parentPath="item.path"
-                :level="item.level + 1"
+                :level="item.level"
+                :showIndentGuides="true"
                 @create-folder="onCreateFolder"
                 @cancel="onCancelCreateFolder"
             />
@@ -580,6 +585,12 @@
                 @dragover="item.type === 'folder' ? onFolderDragOver(item.path, $event) : item.type === 'buffer' ? onBufferDragOver(item.path, $event) : null"
                 @drop="item.type === 'folder' ? onFolderDrop(item.path, $event) : item.type === 'buffer' ? onBufferDrop(item.path, $event) : null"
             >
+                <span
+                    v-for="guideLevel in indentGuides(item.level)"
+                    :key="guideLevel"
+                    class="indent-guide"
+                    :style="{ '--guide-level': guideLevel }"
+                ></span>
                 <span class="name" :title="item.name">{{ item.name }}</span>
             </div>
         </template>
@@ -607,8 +618,9 @@
         padding: 2px 10px
         scroll-margin-top: 36px
         scroll-margin-bottom: 36px
-        padding-left: calc(22px + var(--indent-level) * 16px)
+        padding-left: calc(24px + var(--indent-level) * 20px)
         //border-radius: 4px
+        position: relative
         white-space: nowrap
         overflow: hidden
         text-overflow: ellipsis
@@ -617,21 +629,22 @@
         +dark-mode
             color: rgba(255,255,255, 0.6)
         &.buffer
+            padding-left: calc(13px + var(--indent-level) * 20px)
             &:hover
                 background-color: rgba(0,0,0, 0.06)
                 +dark-mode
-                    background: rgba(255,255,255, 0.08)
+                    background-color: rgba(255,255,255, 0.08)
             &.active
-                background: #d4ded9
+                background-color: #d4ded9
                 +dark-mode
-                    background: #244233
+                    background-color: #244233
             &.scratch
                 font-style: italic
         &.folder
             background-image: url('@/assets/icons/caret-right.svg')
             background-size: 12px
             background-repeat: no-repeat
-            background-position-x: calc(7px + var(--indent-level) * 16px)
+            background-position-x: calc(9px + var(--indent-level) * 20px)
             background-position-y: 6px
             +dark-mode
                 background-image: url('@/assets/icons/caret-right-white.svg')
@@ -648,6 +661,28 @@
                 +dark-mode
                     background-color: rgba(255,255,255, 0.16)
 
+    .indent-guide
+        position: absolute
+        top: 0
+        bottom: 0
+        left: calc(14px + var(--guide-level) * 20px)
+        width: 1px
+        opacity: 0
+        pointer-events: none
+        background: rgba(0,0,0, 0.14)
+        transition: opacity 80ms ease
+        +dark-mode
+            background: rgba(255,255,255, 0.18)
+
+    .buffer-tree:hover .indent-guide,
+    :global(.left-panel:hover) .buffer-tree .indent-guide
+        opacity: 1
+
+    .buffer-tree:hover :deep(.show-indent-guides .indent-guide),
+    :global(.left-panel:hover) .buffer-tree :deep(.show-indent-guides .indent-guide)
+        opacity: 1
+
     .name
         display: block
+        position: relative
 </style>

--- a/src/components/buffer-tree/BufferTree.vue
+++ b/src/components/buffer-tree/BufferTree.vue
@@ -258,6 +258,11 @@
             },
 
             onTreeKeyDown(event) {
+                if (event.key === "Escape") {
+                    event.preventDefault()
+                    this.focusEditor()
+                    return
+                }
                 if (!["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft", "Enter"].includes(event.key)) {
                     return
                 }

--- a/src/components/folder-selector/NewFolderItem.vue
+++ b/src/components/folder-selector/NewFolderItem.vue
@@ -13,6 +13,10 @@
                 type: Boolean,
                 default: true,
             },
+            showIndentGuides: {
+                type: Boolean,
+                default: false,
+            },
         },
 
         data() {
@@ -35,7 +39,8 @@
             className() {
                 return {
                     folder: true,
-                    selected: true
+                    selected: true,
+                    "show-indent-guides": this.showIndentGuides,
                 }
             },
             
@@ -43,7 +48,11 @@
                 return {
                     "--indent-level": this.level,
                 }
-            }
+            },
+
+            indentGuides() {
+                return Array.from({ length: Math.max(0, this.level) }, (_, index) => index)
+            },
         },
 
         methods: {
@@ -100,6 +109,14 @@
         :class="className"
         :style="style"
     >
+        <template v-if="showIndentGuides">
+            <span
+                v-for="guideLevel in indentGuides"
+                :key="guideLevel"
+                class="indent-guide"
+                :style="{ '--guide-level': guideLevel }"
+            ></span>
+        </template>
         <input 
             type="text" 
             v-model="name"
@@ -118,12 +135,23 @@
     .folder
         padding: 3px 6px
         font-size: 13px
-        padding-left: calc(0px + var(--indent-level) * 16px)
+        padding-left: calc(13px + var(--indent-level) * 20px)
         display: flex
-        background: #f1f1f1
-        +dark-mode
-            background-color: #39393a
-                
+        position: relative
+
+        &.show-indent-guides
+            .indent-guide
+                position: absolute
+                top: 0
+                bottom: 0
+                left: calc(14px + var(--guide-level) * 20px)
+                width: 1px
+                opacity: 0
+                pointer-events: none
+                background: rgba(0,0,0, 0.14)
+                transition: opacity 80ms ease
+                +dark-mode
+                    background: rgba(255,255,255, 0.18)
 
         input
             width: 100%
@@ -143,5 +171,9 @@
                 font-size: 12px
             +dark-mode
                 background: #3b3b3b
+
+    :global(.left-panel:hover) .folder.show-indent-guides .indent-guide,
+    :global(.buffer-tree:hover) .folder.show-indent-guides .indent-guide
+        opacity: 1
 
 </style>

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -21,7 +21,7 @@
         mounted() {
             this.searchStore.initializeSearchListeners()
             this.query = this.searchStore.query
-            this.$refs.input.focus()
+            this.focusInput()
         },
 
         beforeUnmount() {
@@ -38,12 +38,18 @@
             wholeWord() {
                 this.search()
             },
+            librarySearchFocusRequestId() {
+                this.focusInput()
+            },
         },
 
         computed: {
             ...mapStores(useSearchStore, useHeynoteStore),
             ...mapState(useSearchStore, [
                 "results",
+            ]),
+            ...mapState(useHeynoteStore, [
+                "librarySearchFocusRequestId",
             ]),
             ...mapWritableState(useSearchStore, [
                 "caseSensitive",
@@ -69,9 +75,14 @@
                 this.searchStore.search(this.query)
             },
 
-            focusEditor() {
-                this.heynoteStore.currentLeftPanel = "buffer-tree"
-                this.heynoteStore.focusEditor()
+            focusInput() {
+                this.$nextTick(() => {
+                    this.$refs.input?.focus()
+                })
+            },
+
+            closeFromEscape() {
+                this.heynoteStore.closeLibrarySearchFromEscape()
             },
         },
     }
@@ -88,7 +99,7 @@
                     placeholder="Find…"
                     class="search-query"
                     main-field
-                    @keydown.esc.prevent.stop="focusEditor"
+                    @keydown.esc.prevent.stop="closeFromEscape"
                 />
                 <div class="input-buttons">
                     <InputToggle 

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -38,6 +38,9 @@
             wholeWord() {
                 this.search()
             },
+            regexp() {
+                this.search()
+            },
             librarySearchFocusRequestId() {
                 this.focusInput()
             },
@@ -47,6 +50,7 @@
             ...mapStores(useSearchStore, useHeynoteStore),
             ...mapState(useSearchStore, [
                 "results",
+                "error",
             ]),
             ...mapState(useHeynoteStore, [
                 "librarySearchFocusRequestId",
@@ -218,9 +222,11 @@
                     <InputToggle 
                         v-model="regexp" 
                         type="regex"
-                        :disabled="true"
                     />
                 </div>
+            </div>
+            <div v-if="error" class="search-error">
+                {{ error }}
             </div>
             <div v-if="hasSearchQuery" class="result-summary">
                 <b>{{ resultCount }}</b> results in <b>{{ bufferCount }}</b> buffers
@@ -269,6 +275,14 @@
                     color: rgba(0,0,0, 0.8)
                     +dark-mode
                         color: rgba(255,255,255, 0.8)
+            .search-error
+                margin-top: 8px
+                padding: 0 1px
+                font-size: 12px
+                line-height: 16px
+                color: #b42318
+                +dark-mode
+                    color: #ffb4ab
             .input-container
                 position: relative
                 flex-grow: 1

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -70,6 +70,7 @@
             },
 
             focusEditor() {
+                this.heynoteStore.currentLeftPanel = "buffer-tree"
                 this.heynoteStore.focusEditor()
             },
         },

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -18,8 +18,25 @@
         },
 
         mounted() {
+            this.searchStore.initializeSearchListeners()
             this.query = this.searchStore.query
             this.$refs.input.focus()
+        },
+
+        beforeUnmount() {
+            this.searchStore.cancelActiveSearch()
+        },
+
+        watch: {
+            query() {
+                this.search()
+            },
+            caseSensitive() {
+                this.search()
+            },
+            wholeWord() {
+                this.search()
+            },
         },
 
         computed: {
@@ -32,22 +49,27 @@
                 "wholeWord",
                 "regexp",
             ]),
+
+            hasSearchQuery() {
+                return this.query.trim().length > 2
+            },
+
+            resultCount() {
+                return this.results.reduce((count, result) => count + result.matches.length, 0)
+            },
+
+            bufferCount() {
+                return this.results.length
+            },
         },
 
         methods: {
             search() {
-                console.log("searching for:", this.query)
                 this.searchStore.search(this.query)
             },
 
-            onToggleClick() {
-                this.search()
-            },
-
-            onQueryKeyUp() {
-                if (this.query.length >= 2) {
-                    this.search()
-                }
+            cancelSearch() {
+                this.searchStore.cancelActiveSearch()
             },
         },
     }
@@ -61,34 +83,38 @@
                     type="text"
                     v-model="query"
                     ref="input"
-                    @keyup="onQueryKeyUp"
                     placeholder="Find…"
                     class="search-query"
                     main-field
+                    @keydown.esc.prevent.stop="cancelSearch"
                 />
                 <div class="input-buttons">
                     <InputToggle 
                         v-model="caseSensitive" 
                         type="case-sensitive"
-                        @click="onToggleClick"
                     />
                     <InputToggle 
                         v-model="wholeWord" 
                         type="whole-words"
-                        @click="onToggleClick"
                     />
                     <InputToggle 
                         v-model="regexp" 
                         type="regex"
-                        @click="onToggleClick"
+                        :disabled="true"
                     />
                 </div>
+            </div>
+            <div v-if="hasSearchQuery" class="result-summary">
+                <b>{{ resultCount }}</b> results in <b>{{ bufferCount }}</b> buffers
             </div>
         </header>
         <div class="results">
             <SearchResult
                 v-for="result in results"
+                :key="result.buffer"
                 :result="result"
+                :query="query"
+                :caseSensitive="caseSensitive"
             />
         </div>
     </div>
@@ -96,50 +122,74 @@
 
 <style lang="sass" scoped>
     .search-container
+        --search-indent-guide-opacity: 0
         font-size: 13px
-        padding: 4px 0px
+        padding: 0px
+        padding-top: 4px
+        display: flex
+        flex-direction: column
+        height: 100%
+        &:hover
+            --search-indent-guide-opacity: 1
 
         .header
             padding: 0 8px 0 10px
-        .input-container
-            position: relative
-            flex-grow: 1
-
-            input[type="text"]
-                background: #fff
-                padding: 6px 5px
-                border: 1px solid #ccc
-                box-sizing: border-box
-                border-radius: 3px
-                width: 100%
-                padding-right: 74px
-                &:focus
-                    outline: none
-                    border: 1px solid #fff
-                    outline: 2px solid #48b57e
-                    border-radius: 2px
-                &::placeholder
-                    color: rgba(0,0,0, 0.6)
+            .result-summary
+                margin-top: 8px
+                padding: 0 1px
+                font-size: 12px
+                line-height: 16px
+                color: rgba(0,0,0, 0.55)
                 +dark-mode
-                    background: #3b3b3b
-                    color: rgba(255,255,255, 0.9)
-                    border: 1px solid #4c4c4c
+                    color: rgba(255,255,255, 0.55)
+                b
+                    color: rgba(0,0,0, 0.8)
+                    +dark-mode
+                        color: rgba(255,255,255, 0.8)
+            .input-container
+                position: relative
+                flex-grow: 1
+
+                input[type="text"]
+                    background: #fff
+                    padding: 6px 5px
+                    border: 1px solid #ccc
+                    box-sizing: border-box
+                    border-radius: 3px
+                    width: 100%
+                    padding-right: 74px
                     &:focus
-                        border: 1px solid #3b3b3b
+                        outline: none
+                        border: 1px solid #fff
+                        outline: 2px solid #48b57e
+                        border-radius: 2px
                     &::placeholder
-                        color: rgba(255,255,255, 0.6)
-                +webapp-mobile
-                    font-size: 16px
-                    max-width: 100%
-            
-            .input-buttons
-                position: absolute
-                top: 0
-                right: 2px
-                bottom: 0
-                display: flex
-                align-items: center
+                        color: rgba(0,0,0, 0.6)
+                    +dark-mode
+                        background: #3b3b3b
+                        color: rgba(255,255,255, 0.9)
+                        border: 1px solid #4c4c4c
+                        &:focus
+                            border: 1px solid #3b3b3b
+                        &::placeholder
+                            color: rgba(255,255,255, 0.6)
+                    +webapp-mobile
+                        font-size: 16px
+                        max-width: 100%
+                
+                .input-buttons
+                    position: absolute
+                    top: 0
+                    right: 2px
+                    bottom: 0
+                    display: flex
+                    align-items: center
         
         .results
             padding-top: 12px
+            overflow-y: scroll
+            height: 100%
+
+    :global(.left-panel:hover) .search-container
+        --search-indent-guide-opacity: 1
 </style>

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -83,7 +83,11 @@
 
             focusFirstResult() {
                 this.$nextTick(() => {
-                    this.$el?.querySelector(".search-result-row")?.focus()
+                    const row = this.resultRows()[0]
+                    if (row) {
+                        this.selectRow(row)
+                        this.focusResults()
+                    }
                 })
             },
 
@@ -93,6 +97,92 @@
                 }
                 event.preventDefault()
                 this.focusFirstResult()
+            },
+
+            resultRows() {
+                return [...(this.$refs.results?.querySelectorAll(".search-result-row") || [])]
+            },
+
+            selectedRow() {
+                return this.$refs.results?.querySelector(".search-result-row.selected")
+            },
+
+            selectRow(row) {
+                if (!row) {
+                    return
+                }
+
+                if (row.dataset.rowType === "buffer") {
+                    this.searchStore.selectBuffer(row.dataset.buffer)
+                } else if (row.dataset.rowType === "match") {
+                    this.searchStore.selectMatch({
+                        buffer: row.dataset.buffer,
+                        lineNumber: Number(row.dataset.lineNumber),
+                        line: row.dataset.line,
+                    })
+                }
+                row.scrollIntoView({
+                    behavior: "auto",
+                    block: "nearest",
+                })
+            },
+
+            focusResults() {
+                this.$refs.results?.focus({ preventScroll: true })
+            },
+
+            moveSelectedRow(direction) {
+                const rows = this.resultRows()
+                if (rows.length === 0) {
+                    return
+                }
+                const currentIndex = rows.indexOf(this.selectedRow())
+                const nextIndex = currentIndex === -1
+                    ? 0
+                    : Math.max(0, Math.min(rows.length - 1, currentIndex + direction))
+                this.selectRow(rows[nextIndex])
+            },
+
+            activateSelectedRow() {
+                this.selectedRow()?.click()
+            },
+
+            setSelectedBufferOpen(open) {
+                const row = this.selectedRow()
+                if (!row || row.dataset.rowType !== "buffer") {
+                    return
+                }
+                if (row.classList.contains("open") !== open) {
+                    row.click()
+                }
+            },
+
+            onResultsKeyDown(event) {
+                if (event.key === "Escape") {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    this.closeFromEscape()
+                    return
+                }
+                if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                    event.preventDefault()
+                    this.moveSelectedRow(event.key === "ArrowDown" ? 1 : -1)
+                    return
+                }
+                if (event.key === "ArrowRight") {
+                    event.preventDefault()
+                    this.setSelectedBufferOpen(true)
+                    return
+                }
+                if (event.key === "ArrowLeft") {
+                    event.preventDefault()
+                    this.setSelectedBufferOpen(false)
+                    return
+                }
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault()
+                    this.activateSelectedRow()
+                }
             },
 
             closeFromEscape() {
@@ -136,7 +226,12 @@
                 <b>{{ resultCount }}</b> results in <b>{{ bufferCount }}</b> buffers
             </div>
         </header>
-        <div class="results">
+        <div
+            class="results"
+            ref="results"
+            tabindex="0"
+            @keydown="onResultsKeyDown"
+        >
             <SearchResult
                 v-for="result in results"
                 :key="result.buffer"
@@ -217,6 +312,12 @@
             padding-top: 12px
             overflow-y: scroll
             height: 100%
+            &:focus
+                outline: none
+                :deep(.search-result-row.selected)
+                    outline: 1px solid #48b57e
+                    outline-offset: -1px
+                    z-index: 1
 
     :global(.left-panel:hover) .search-container
         --search-indent-guide-opacity: 1

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -2,6 +2,7 @@
     import { mapState, mapStores, mapWritableState } from "pinia"
 
     import { useSearchStore } from '@/src/stores/search-store';
+    import { useHeynoteStore } from "@/src/stores/heynote-store";
     import InputToggle from '@/src/editor/search/InputToggle.vue';
     import SearchResult from "./SearchResult.vue";
 
@@ -40,7 +41,7 @@
         },
 
         computed: {
-            ...mapStores(useSearchStore),
+            ...mapStores(useSearchStore, useHeynoteStore),
             ...mapState(useSearchStore, [
                 "results",
             ]),
@@ -68,8 +69,8 @@
                 this.searchStore.search(this.query)
             },
 
-            cancelSearch() {
-                this.searchStore.cancelActiveSearch()
+            focusEditor() {
+                this.heynoteStore.focusEditor()
             },
         },
     }
@@ -86,7 +87,7 @@
                     placeholder="Find…"
                     class="search-query"
                     main-field
-                    @keydown.esc.prevent.stop="cancelSearch"
+                    @keydown.esc.prevent.stop="focusEditor"
                 />
                 <div class="input-buttons">
                     <InputToggle 

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -81,6 +81,20 @@
                 })
             },
 
+            focusFirstResult() {
+                this.$nextTick(() => {
+                    this.$el?.querySelector(".search-result-row")?.focus()
+                })
+            },
+
+            onInputKeyDown(event) {
+                if (event.key !== "ArrowDown") {
+                    return
+                }
+                event.preventDefault()
+                this.focusFirstResult()
+            },
+
             closeFromEscape() {
                 this.heynoteStore.closeLibrarySearchFromEscape()
             },
@@ -99,6 +113,7 @@
                     placeholder="Find…"
                     class="search-query"
                     main-field
+                    @keydown="onInputKeyDown"
                     @keydown.esc.prevent.stop="closeFromEscape"
                 />
                 <div class="input-buttons">

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -3,6 +3,7 @@
 
     import { useSearchStore } from '@/src/stores/search-store';
     import { useHeynoteStore } from "@/src/stores/heynote-store";
+    import { useSettingsStore } from "@/src/stores/settings-store.js";
     import InputToggle from '@/src/editor/search/InputToggle.vue';
     import SearchResult from "./SearchResult.vue";
 
@@ -33,12 +34,15 @@
                 this.search()
             },
             caseSensitive() {
+                this.persistLibrarySearchSettings()
                 this.search()
             },
             wholeWord() {
+                this.persistLibrarySearchSettings()
                 this.search()
             },
             regexp() {
+                this.persistLibrarySearchSettings()
                 this.search()
             },
             librarySearchFocusRequestId() {
@@ -47,7 +51,7 @@
         },
 
         computed: {
-            ...mapStores(useSearchStore, useHeynoteStore),
+            ...mapStores(useSearchStore, useHeynoteStore, useSettingsStore),
             ...mapState(useSearchStore, [
                 "results",
                 "error",
@@ -75,6 +79,17 @@
         },
 
         methods: {
+            persistLibrarySearchSettings() {
+                this.settingsStore.updateSettings({
+                    librarySearchSettings: {
+                        ...(this.settingsStore.settings.librarySearchSettings || {}),
+                        caseSensitive: this.caseSensitive,
+                        wholeWord: this.wholeWord,
+                        regexp: this.regexp,
+                    },
+                })
+            },
+
             search() {
                 this.searchStore.search(this.query)
             },

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -1,0 +1,145 @@
+<script>
+    import { mapState, mapStores, mapWritableState } from "pinia"
+
+    import { useSearchStore } from '@/src/stores/search-store';
+    import InputToggle from '@/src/editor/search/InputToggle.vue';
+    import SearchResult from "./SearchResult.vue";
+
+    export default {
+        components: {
+            InputToggle,
+            SearchResult,
+        },
+
+        data() {
+            return {
+                query: "",
+            }
+        },
+
+        mounted() {
+            this.query = this.searchStore.query
+            this.$refs.input.focus()
+        },
+
+        computed: {
+            ...mapStores(useSearchStore),
+            ...mapState(useSearchStore, [
+                "results",
+            ]),
+            ...mapWritableState(useSearchStore, [
+                "caseSensitive",
+                "wholeWord",
+                "regexp",
+            ]),
+        },
+
+        methods: {
+            search() {
+                console.log("searching for:", this.query)
+                this.searchStore.search(this.query)
+            },
+
+            onToggleClick() {
+                this.search()
+            },
+
+            onQueryKeyUp() {
+                if (this.query.length >= 2) {
+                    this.search()
+                }
+            },
+        },
+    }
+</script>
+
+<template>
+    <div class="search-container">
+        <header class="header">
+            <div class="input-container">
+                <input
+                    type="text"
+                    v-model="query"
+                    ref="input"
+                    @keyup="onQueryKeyUp"
+                    placeholder="Find…"
+                    class="search-query"
+                    main-field
+                />
+                <div class="input-buttons">
+                    <InputToggle 
+                        v-model="caseSensitive" 
+                        type="case-sensitive"
+                        @click="onToggleClick"
+                    />
+                    <InputToggle 
+                        v-model="wholeWord" 
+                        type="whole-words"
+                        @click="onToggleClick"
+                    />
+                    <InputToggle 
+                        v-model="regexp" 
+                        type="regex"
+                        @click="onToggleClick"
+                    />
+                </div>
+            </div>
+        </header>
+        <div class="results">
+            <SearchResult
+                v-for="result in results"
+                :result="result"
+            />
+        </div>
+    </div>
+</template>
+
+<style lang="sass" scoped>
+    .search-container
+        font-size: 13px
+        padding: 4px 0px
+
+        .header
+            padding: 0 8px 0 10px
+        .input-container
+            position: relative
+            flex-grow: 1
+
+            input[type="text"]
+                background: #fff
+                padding: 6px 5px
+                border: 1px solid #ccc
+                box-sizing: border-box
+                border-radius: 3px
+                width: 100%
+                padding-right: 74px
+                &:focus
+                    outline: none
+                    border: 1px solid #fff
+                    outline: 2px solid #48b57e
+                    border-radius: 2px
+                &::placeholder
+                    color: rgba(0,0,0, 0.6)
+                +dark-mode
+                    background: #3b3b3b
+                    color: rgba(255,255,255, 0.9)
+                    border: 1px solid #4c4c4c
+                    &:focus
+                        border: 1px solid #3b3b3b
+                    &::placeholder
+                        color: rgba(255,255,255, 0.6)
+                +webapp-mobile
+                    font-size: 16px
+                    max-width: 100%
+            
+            .input-buttons
+                position: absolute
+                top: 0
+                right: 2px
+                bottom: 0
+                display: flex
+                align-items: center
+        
+        .results
+            padding-top: 12px
+</style>

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -94,11 +94,12 @@
             },
 
             highlightedParts(match) {
-                const submatches = this.normalizedSubmatches(match)
+                const line = match.displayLine || match.line
+                const submatches = this.normalizedSubmatchList(match.displaySubmatches || match.submatches)
                 if (submatches.length === 0) {
-                    return [{ text: match.line, highlight: false }]
+                    return [{ text: line, highlight: false }]
                 }
-                const preview = this.matchPreview(match.line, submatches[0].start)
+                const preview = this.matchPreview(line, submatches[0].start)
                 const visibleLine = preview.line
                 const parts = []
                 let cursor = 0
@@ -121,7 +122,11 @@
             },
 
             normalizedSubmatches(match) {
-                return (match.submatches || [])
+                return this.normalizedSubmatchList(match.submatches)
+            },
+
+            normalizedSubmatchList(submatches) {
+                return (submatches || [])
                     .filter((submatch) => (
                         Number.isInteger(submatch.start) &&
                         Number.isInteger(submatch.end) &&

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -274,7 +274,8 @@
                 vertical-align: middle
             .dir
                 margin-left: 10px
-                font-size: 0.8em
+                font-size: 0.9em
+                vertical-align: middle
                 opacity: 0.65
         .matches 
             .match

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -1,0 +1,48 @@
+<script>
+    import { mapStores } from "pinia"
+
+    import { useHeynoteStore } from "@/src/stores/heynote-store"
+
+    export default {
+        props: ["result"],
+
+        computed: {
+            ...mapStores(useHeynoteStore),
+
+            bufferName() {
+                const buffer = this.heynoteStore.buffers[this.result.buffer]
+                return buffer ? buffer.name : this.result.buffer
+            },
+        }
+    }
+</script>
+
+<template>
+    <div class="result-container">
+        <div class="buffer">{{ bufferName }}</div>
+        <div class="matches">
+            <div class="match" v-for="match in result.matches">
+                {{ match.line }}
+            </div>
+        </div>
+    </div>
+</template>
+
+<style lang="sass" scoped>
+    .result-container
+        color: rgba(0,0,0, 0.7)
+        +dark-mode
+            color: rgba(255,255,255, 0.7)
+        .buffer
+            cursor: pointer
+            padding: 5px 10px
+            &:hover
+                background: rgba(255,255,255, 0.1)
+        .matches 
+            .match
+                cursor: pointer
+                padding: 5px 20px
+                //font-family: "Hack",
+                &:hover
+                    background: rgba(255,255,255, 0.1)
+</style>

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -4,7 +4,7 @@
     import { useHeynoteStore } from "@/src/stores/heynote-store"
     import { useSearchStore } from "@/src/stores/search-store"
 
-    const MATCH_PREVIEW_CONTEXT_LENGTH = 30
+    const MATCH_PREVIEW_CONTEXT_LENGTH = 20
     // Reuse one segmenter across result rows; constructing it per row is expensive
     // when a search streams thousands of matches.
     const graphemeSegmenter = Intl?.Segmenter

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -11,7 +11,12 @@
 
             bufferName() {
                 const buffer = this.heynoteStore.buffers[this.result.buffer]
-                return buffer ? buffer.name : this.result.buffer
+                return buffer?.name ? buffer.name : this.result.buffer.split(window.heynote.buffer.pathSeparator).at(-1)
+            },
+
+            bufferDir() {
+                const parts = this.result.buffer.split(window.heynote.buffer.pathSeparator)
+                return parts.at(-2)
             },
         }
     }
@@ -19,7 +24,10 @@
 
 <template>
     <div class="result-container">
-        <div class="buffer">{{ bufferName }}</div>
+        <div class="buffer">
+            {{ bufferName }}
+            <span class="dir">{{ bufferDir }}</span>
+        </div>
         <div class="matches">
             <div class="match" v-for="match in result.matches">
                 {{ match.line }}
@@ -38,6 +46,9 @@
             padding: 5px 10px
             &:hover
                 background: rgba(255,255,255, 0.1)
+            .dir
+                margin-left: 10px
+                font-size: 0.8em
         .matches 
             .match
                 cursor: pointer

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -48,6 +48,56 @@
                 this.$nextTick(() => this.focusEditor())
             },
 
+            onBufferKeyDown(event) {
+                if (this.moveFocusWithArrowKey(event)) {
+                    return
+                }
+                if (event.key === "ArrowRight") {
+                    event.preventDefault()
+                    this.open = true
+                    return
+                }
+                if (event.key === "ArrowLeft") {
+                    event.preventDefault()
+                    this.open = false
+                    return
+                }
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault()
+                    this.toggleOpen()
+                }
+            },
+
+            onMatchKeyDown(event) {
+                if (this.moveFocusWithArrowKey(event)) {
+                    return
+                }
+                if (event.key === "Enter") {
+                    event.preventDefault()
+                    this.openMatch()
+                }
+            },
+
+            moveFocusWithArrowKey(event) {
+                const direction = event.key === "ArrowDown" ? 1 : event.key === "ArrowUp" ? -1 : 0
+                if (direction === 0) {
+                    return false
+                }
+                event.preventDefault()
+                const rows = [...(this.$el.closest(".search-container")?.querySelectorAll(".search-result-row") || [])]
+                const currentIndex = rows.indexOf(event.currentTarget)
+                if (currentIndex === -1) {
+                    return true
+                }
+                const nextIndex = Math.max(0, Math.min(rows.length - 1, currentIndex + direction))
+                rows[nextIndex]?.focus()
+                rows[nextIndex]?.scrollIntoView({
+                    behavior: "auto",
+                    block: "nearest",
+                })
+                return true
+            },
+
             highlightedParts(match) {
                 const submatches = this.normalizedSubmatches(match)
                 if (submatches.length === 0) {
@@ -147,19 +197,23 @@
 <template>
     <div class="result-container">
         <div
-            :class="{ buffer: true, open }"
+            :class="{ buffer: true, open, 'search-result-row': true }"
             :title="result.buffer"
+            tabindex="0"
             @click="toggleOpen"
+            @keydown="onBufferKeyDown"
         >
             <span class="name">{{ bufferName }}</span>
             <span v-if="bufferDir" class="dir">{{ bufferDir }}</span>
         </div>
         <div v-if="open" class="matches">
             <div
-                class="match"
+                class="match search-result-row"
                 v-for="match in result.matches"
                 :key="match.lineNumber + ':' + match.line"
+                tabindex="0"
                 @click="openMatch"
+                @keydown="onMatchKeyDown"
             >
                 <span
                     v-for="guideLevel in indentGuides(1)"
@@ -208,6 +262,12 @@
                 background-color: rgba(0,0,0, 0.06)
                 +dark-mode
                     background-color: rgba(255,255,255, 0.08)
+            &:focus
+                outline: none
+            &:focus-visible
+                outline: 1px solid #48b57e
+                outline-offset: -1px
+                z-index: 1
             .name
                 vertical-align: middle
             .dir
@@ -228,6 +288,12 @@
                     background-color: rgba(0,0,0, 0.06)
                     +dark-mode
                         background-color: rgba(255,255,255, 0.08)
+                &:focus
+                    outline: none
+                &:focus-visible
+                    outline: 1px solid #48b57e
+                    outline-offset: -1px
+                    z-index: 1
                 .indent-guide
                     position: absolute
                     top: 0

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -2,6 +2,7 @@
     import { mapActions, mapStores } from "pinia"
 
     import { useHeynoteStore } from "@/src/stores/heynote-store"
+    import { useSearchStore } from "@/src/stores/search-store"
 
     const MATCH_PREVIEW_CONTEXT_LENGTH = 30
     // Reuse one segmenter across result rows; constructing it per row is expensive
@@ -20,7 +21,7 @@
         },
 
         computed: {
-            ...mapStores(useHeynoteStore),
+            ...mapStores(useHeynoteStore, useSearchStore),
 
             bufferName() {
                 const buffer = this.heynoteStore.buffers[this.result.buffer]
@@ -36,66 +37,60 @@
         methods: {
             ...mapActions(useHeynoteStore, [
                 "openBuffer",
-                "focusEditor",
             ]),
 
             toggleOpen() {
                 this.open = !this.open
             },
 
-            openMatch() {
-                this.openBuffer(this.result.buffer)
-                this.$nextTick(() => this.focusEditor())
+            toggleBuffer(event) {
+                this.searchStore.selectBuffer(this.result.buffer)
+                this.toggleOpen()
+                this.focusResults(event.currentTarget)
             },
 
-            onBufferKeyDown(event) {
-                if (this.moveFocusWithArrowKey(event)) {
-                    return
-                }
-                if (event.key === "ArrowRight") {
-                    event.preventDefault()
-                    this.open = true
-                    return
-                }
-                if (event.key === "ArrowLeft") {
-                    event.preventDefault()
-                    this.open = false
-                    return
-                }
-                if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault()
-                    this.toggleOpen()
-                }
-            },
-
-            onMatchKeyDown(event) {
-                if (this.moveFocusWithArrowKey(event)) {
-                    return
-                }
-                if (event.key === "Enter") {
-                    event.preventDefault()
-                    this.openMatch()
-                }
-            },
-
-            moveFocusWithArrowKey(event) {
-                const direction = event.key === "ArrowDown" ? 1 : event.key === "ArrowUp" ? -1 : 0
-                if (direction === 0) {
-                    return false
-                }
-                event.preventDefault()
-                const rows = [...(this.$el.closest(".search-container")?.querySelectorAll(".search-result-row") || [])]
-                const currentIndex = rows.indexOf(event.currentTarget)
-                if (currentIndex === -1) {
-                    return true
-                }
-                const nextIndex = Math.max(0, Math.min(rows.length - 1, currentIndex + direction))
-                rows[nextIndex]?.focus()
-                rows[nextIndex]?.scrollIntoView({
-                    behavior: "auto",
-                    block: "nearest",
+            async openMatch(match, focusTarget) {
+                this.searchStore.selectMatch({
+                    buffer: this.result.buffer,
+                    ...match,
                 })
-                return true
+                this.openBuffer(this.result.buffer, { focusEditor: false })
+                await this.$nextTick()
+
+                const editor = this.heynoteStore.currentEditor
+                await editor?.contentLoadedPromise
+
+                if (this.heynoteStore.currentBufferPath !== this.result.buffer) {
+                    return
+                }
+
+                const firstSubmatch = this.normalizedSubmatches(match)[0]
+                if (firstSubmatch) {
+                    editor?.setSelectionAtLineColumns(match.lineNumber, firstSubmatch.start, firstSubmatch.end)
+                } else {
+                    editor?.setCursorPositionAtLineColumn(match.lineNumber)
+                }
+                if (this.heynoteStore.currentLeftPanel === "search" && focusTarget?.isConnected) {
+                    focusTarget.focus({ preventScroll: true })
+                }
+            },
+
+            focusResults(element) {
+                element?.closest(".results")?.focus({ preventScroll: true })
+            },
+
+            isSelectedBuffer() {
+                const selectedRow = this.searchStore.selectedResultRow
+                return selectedRow?.type === "buffer" &&
+                    selectedRow.buffer === this.result.buffer
+            },
+
+            isSelectedMatch(match) {
+                const selectedRow = this.searchStore.selectedResultRow
+                return selectedRow?.type === "match" &&
+                    selectedRow.buffer === this.result.buffer &&
+                    selectedRow.lineNumber === match.lineNumber &&
+                    selectedRow.line === match.line
             },
 
             highlightedParts(match) {
@@ -197,23 +192,25 @@
 <template>
     <div class="result-container">
         <div
-            :class="{ buffer: true, open, 'search-result-row': true }"
+            :class="{ buffer: true, open, 'search-result-row': true, selected: isSelectedBuffer() }"
             :title="result.buffer"
-            tabindex="0"
-            @click="toggleOpen"
-            @keydown="onBufferKeyDown"
+            data-row-type="buffer"
+            :data-buffer="result.buffer"
+            @click="toggleBuffer"
         >
             <span class="name">{{ bufferName }}</span>
             <span v-if="bufferDir" class="dir">{{ bufferDir }}</span>
         </div>
         <div v-if="open" class="matches">
             <div
-                class="match search-result-row"
+                :class="{ match: true, 'search-result-row': true, selected: isSelectedMatch(match) }"
                 v-for="match in result.matches"
                 :key="match.lineNumber + ':' + match.line"
-                tabindex="0"
-                @click="openMatch"
-                @keydown="onMatchKeyDown"
+                data-row-type="match"
+                :data-buffer="result.buffer"
+                :data-line-number="match.lineNumber"
+                :data-line="match.line"
+                @click="openMatch(match, $event.currentTarget.closest('.results'))"
             >
                 <span
                     v-for="guideLevel in indentGuides(1)"

--- a/src/components/library-search/SearchResult.vue
+++ b/src/components/library-search/SearchResult.vue
@@ -1,10 +1,23 @@
 <script>
-    import { mapStores } from "pinia"
+    import { mapActions, mapStores } from "pinia"
 
     import { useHeynoteStore } from "@/src/stores/heynote-store"
 
+    const MATCH_PREVIEW_CONTEXT_LENGTH = 30
+    // Reuse one segmenter across result rows; constructing it per row is expensive
+    // when a search streams thousands of matches.
+    const graphemeSegmenter = Intl?.Segmenter
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : null
+
     export default {
-        props: ["result"],
+        props: ["result", "query", "caseSensitive"],
+
+        data() {
+            return {
+                open: true,
+            }
+        },
 
         computed: {
             ...mapStores(useHeynoteStore),
@@ -18,19 +31,151 @@
                 const parts = this.result.buffer.split(window.heynote.buffer.pathSeparator)
                 return parts.at(-2)
             },
-        }
+        },
+
+        methods: {
+            ...mapActions(useHeynoteStore, [
+                "openBuffer",
+                "focusEditor",
+            ]),
+
+            toggleOpen() {
+                this.open = !this.open
+            },
+
+            openMatch() {
+                this.openBuffer(this.result.buffer)
+                this.$nextTick(() => this.focusEditor())
+            },
+
+            highlightedParts(match) {
+                const submatches = this.normalizedSubmatches(match)
+                if (submatches.length === 0) {
+                    return [{ text: match.line, highlight: false }]
+                }
+                const preview = this.matchPreview(match.line, submatches[0].start)
+                const visibleLine = preview.line
+                const parts = []
+                let cursor = 0
+                for (const submatch of submatches) {
+                    const start = Math.max(preview.prefixLength, submatch.start - preview.startIndex + preview.prefixLength)
+                    const end = Math.min(visibleLine.length, submatch.end - preview.startIndex + preview.prefixLength)
+                    if (end <= start || end <= cursor) {
+                        continue
+                    }
+                    if (start > cursor) {
+                        parts.push({ text: visibleLine.slice(cursor, start), highlight: false })
+                    }
+                    parts.push({ text: visibleLine.slice(start, end), highlight: true })
+                    cursor = end
+                }
+                if (cursor < visibleLine.length) {
+                    parts.push({ text: visibleLine.slice(cursor), highlight: false })
+                }
+                return parts.length ? parts : [{ text: visibleLine, highlight: false }]
+            },
+
+            normalizedSubmatches(match) {
+                return (match.submatches || [])
+                    .filter((submatch) => (
+                        Number.isInteger(submatch.start) &&
+                        Number.isInteger(submatch.end) &&
+                        submatch.end > submatch.start
+                    ))
+                    .sort((a, b) => a.start - b.start)
+            },
+
+            matchPreview(line, firstMatchIndex) {
+                if (firstMatchIndex <= MATCH_PREVIEW_CONTEXT_LENGTH) {
+                    return {
+                        line,
+                        startIndex: 0,
+                        prefixLength: 0,
+                    }
+                }
+                const lineBeforeMatch = line.slice(0, firstMatchIndex)
+                const previewStart = this.previewStartIndex(lineBeforeMatch)
+                if (previewStart === 0) {
+                    return {
+                        line,
+                        startIndex: 0,
+                        prefixLength: 0,
+                    }
+                }
+                return {
+                    line: "..." + line.slice(previewStart),
+                    startIndex: previewStart,
+                    prefixLength: 3,
+                }
+            },
+
+            previewStartIndex(text) {
+                // Keep only the last N grapheme start offsets so long lines do not
+                // allocate an array of every segment before the match.
+                const recentIndexes = []
+                let count = 0
+                if (graphemeSegmenter) {
+                    for (const { index } of graphemeSegmenter.segment(text)) {
+                        count++
+                        recentIndexes.push(index)
+                        if (recentIndexes.length > MATCH_PREVIEW_CONTEXT_LENGTH) {
+                            recentIndexes.shift()
+                        }
+                    }
+                    return count > MATCH_PREVIEW_CONTEXT_LENGTH ? recentIndexes[0] : 0
+                }
+
+                let index = 0
+                for (const codePoint of text) {
+                    count++
+                    recentIndexes.push(index)
+                    if (recentIndexes.length > MATCH_PREVIEW_CONTEXT_LENGTH) {
+                        recentIndexes.shift()
+                    }
+                    index += codePoint.length
+                }
+                return count > MATCH_PREVIEW_CONTEXT_LENGTH ? recentIndexes[0] : 0
+            },
+
+            indentGuides(level) {
+                return Array.from({ length: Math.max(0, level) }, (_, index) => index)
+            },
+        },
     }
 </script>
 
 <template>
     <div class="result-container">
-        <div class="buffer">
-            {{ bufferName }}
-            <span class="dir">{{ bufferDir }}</span>
+        <div
+            :class="{ buffer: true, open }"
+            :title="result.buffer"
+            @click="toggleOpen"
+        >
+            <span class="name">{{ bufferName }}</span>
+            <span v-if="bufferDir" class="dir">{{ bufferDir }}</span>
         </div>
-        <div class="matches">
-            <div class="match" v-for="match in result.matches">
-                {{ match.line }}
+        <div v-if="open" class="matches">
+            <div
+                class="match"
+                v-for="match in result.matches"
+                :key="match.lineNumber + ':' + match.line"
+                @click="openMatch"
+            >
+                <span
+                    v-for="guideLevel in indentGuides(1)"
+                    :key="guideLevel"
+                    class="indent-guide"
+                    :style="{ '--guide-level': guideLevel }"
+                ></span>
+                <span class="line-text">
+                    <template
+                        v-for="(part, index) in highlightedParts(match)"
+                        :key="index"
+                    >
+                        <strong v-if="part.highlight">{{ part.text }}</strong>
+                        <template v-else>{{ part.text }}</template>
+                    </template>
+                </span>
             </div>
         </div>
     </div>
@@ -43,17 +188,70 @@
             color: rgba(255,255,255, 0.7)
         .buffer
             cursor: pointer
-            padding: 5px 10px
+            line-height: 20px
+            padding: 2px 10px 2px 24px
+            position: relative
+            white-space: nowrap
+            overflow: hidden
+            text-overflow: ellipsis
+            background-image: url('@/assets/icons/caret-right.svg')
+            background-size: 12px
+            background-repeat: no-repeat
+            background-position: 9px 6px
+            +dark-mode
+                background-image: url('@/assets/icons/caret-right-white.svg')
+            &.open
+                background-image: url('@/assets/icons/caret-down.svg')
+                +dark-mode
+                    background-image: url('@/assets/icons/caret-down-white.svg')
             &:hover
-                background: rgba(255,255,255, 0.1)
+                background-color: rgba(0,0,0, 0.06)
+                +dark-mode
+                    background-color: rgba(255,255,255, 0.08)
+            .name
+                vertical-align: middle
             .dir
                 margin-left: 10px
                 font-size: 0.8em
+                opacity: 0.65
         .matches 
             .match
                 cursor: pointer
-                padding: 5px 20px
-                //font-family: "Hack",
+                display: flex
+                gap: 8px
+                line-height: 20px
+                padding: 2px 10px 2px 34px
+                white-space: nowrap
+                overflow: hidden
+                position: relative
                 &:hover
-                    background: rgba(255,255,255, 0.1)
+                    background-color: rgba(0,0,0, 0.06)
+                    +dark-mode
+                        background-color: rgba(255,255,255, 0.08)
+                .indent-guide
+                    position: absolute
+                    top: 0
+                    bottom: 0
+                    left: calc(14px + var(--guide-level) * 20px)
+                    width: 1px
+                    opacity: var(--search-indent-guide-opacity, 0)
+                    pointer-events: none
+                    background: rgba(0,0,0, 0.14)
+                    transition: opacity 80ms ease
+                    +dark-mode
+                        background: rgba(255,255,255, 0.18)
+                .line-number
+                    flex: 0 0 32px
+                    text-align: right
+                    opacity: 0.55
+                    font-variant-numeric: tabular-nums
+                .line-text
+                    min-width: 0
+                    overflow: hidden
+                    text-overflow: ellipsis
+                    strong
+                        font-weight: 700
+                        color: rgba(0,0,0, 0.88)
+                        +dark-mode
+                            color: rgba(255,255,255, 0.95)
 </style>

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -44,7 +44,7 @@
                 showWhitespace: this.initialSettings.showWhitespace,
                 showTabs: this.initialSettings.showTabs,
                 showTabsInFullscreen: this.initialSettings.showTabsInFullscreen,
-                showLeftPanel: this.initialSettings.showLeftPanel ?? false,
+                showLeftPanel: this.initialSettings.showLeftPanel ?? true,
                 allowBetaVersions: this.initialSettings.allowBetaVersions,
                 enableGlobalHotkey: this.initialSettings.enableGlobalHotkey,
                 globalHotkey: this.initialSettings.globalHotkey,

--- a/src/css/base.sass
+++ b/src/css/base.sass
@@ -4,7 +4,7 @@
     --tab-bar-height: 30px
     --status-bar-height: 21px
     --system-font: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
-    --left-panel-width: 220px
+    --left-panel-width: 250px
 
 :root[theme='light']
     --status-bar-background: #48b57e

--- a/src/editor/commands.js
+++ b/src/editor/commands.js
@@ -110,6 +110,13 @@ export function toggleLeftPanel(editor) {
     }
 }
 
+export function openLibrarySearch(editor) {
+    return (view) => {
+        useHeynoteStore().openLibrarySearch()
+        return true
+    }
+}
+
 const nothing = (view) => {
     return true
 }
@@ -155,6 +162,7 @@ const HEYNOTE_COMMANDS = {
     unfoldBlock: cmd(unfoldBlock, "Block", "Unfold block"),
     toggleBlockFold: cmd(toggleBlockFold, "Block", "Toggle block fold"),
     toggleLeftPanel: cmd(toggleLeftPanel, "Editor", "Toggle left sidebar panel"),
+    openLibrarySearch: cmd(openLibrarySearch, "Search", "Open library search"),
 
     // tab commands
     closeCurrentTab: cmd(closeCurrentTab, "Buffer", "Close current tab"),

--- a/src/editor/commands.js
+++ b/src/editor/commands.js
@@ -121,20 +121,24 @@ const nothing = (view) => {
     return true
 }
 
-const cmd = (f, category, description) => ({
+const cmd = (f, category, description, options={}) => ({
     run: f,
     name: f.name,
     description: description,
     category: category,
+    global: options.global || false,
 })
 
-const cmdLessContext = (f, category, description) => ({
+const cmdLessContext = (f, category, description, options={}) => ({
     run: (editor) => f,
     name: f.name,
     description: description,
     category: category,
+    global: options.global || false,
 })
 
+// if global is set, the command will work when the editor doesn't have focus (e.g. in the search panel)
+const global = {global: true}
 
 const HEYNOTE_COMMANDS = {
     addNewBlockAfterCurrent: cmd(addNewBlockAfterCurrent, "Block", "Add new block after current block"),
@@ -152,37 +156,37 @@ const HEYNOTE_COMMANDS = {
     toggleSelectionMarkMode: cmd(toggleSelectionMarkMode, "Cursor", "Toggle selection mark mode"),
     selectionMarkModeCancel: cmd(selectionMarkModeCancel, "Cursor", "Cancel selection mark mode"),
     openLanguageSelector: cmd(openLanguageSelector, "Block", "Select block language…"),
-    openBufferSelector: cmd(openBufferSelector, "Buffer", "Switch buffer…"),
-    openCommandPalette: cmd(openCommandPalette, "Editor", "Open command palette…"),
+    openBufferSelector: cmd(openBufferSelector, "Buffer", "Switch buffer…", global),
+    openCommandPalette: cmd(openCommandPalette, "Editor", "Open command palette…", global),
     openMoveToBuffer: cmd(openMoveToBuffer, "Block", "Move block to another buffer…"),
-    openCreateNewBuffer: cmd(openCreateNewBuffer, "Buffer", "Create new buffer…"),
+    openCreateNewBuffer: cmd(openCreateNewBuffer, "Buffer", "Create new buffer…", global),
     cut: cmd(cutCommand, "Clipboard", "Cut selection"),
     copy: cmd(copyCommand, "Clipboard", "Copy selection"),
     foldBlock: cmd(foldBlock, "Block", "Fold block"),
     unfoldBlock: cmd(unfoldBlock, "Block", "Unfold block"),
     toggleBlockFold: cmd(toggleBlockFold, "Block", "Toggle block fold"),
-    toggleLeftPanel: cmd(toggleLeftPanel, "Editor", "Toggle left sidebar panel"),
-    openLibrarySearch: cmd(openLibrarySearch, "Search", "Open library search"),
+    toggleLeftPanel: cmd(toggleLeftPanel, "Editor", "Toggle left sidebar panel", global),
+    openLibrarySearch: cmd(openLibrarySearch, "Search", "Open library search", global),
 
     // tab commands
-    closeCurrentTab: cmd(closeCurrentTab, "Buffer", "Close current tab"),
-    reopenLastClosedTab: cmd(reopenLastClosedTab, "Buffer", "Reopen last closed tab"),
-    switchToLastTab: cmd(switchToLastTab, "Buffer", "Switch to last tab"),
-    previousTab: cmd(previousTab, "Buffer", "Switch to previous tab"),
-    nextTab: cmd(nextTab, "Buffer", "Switch to next tab"),
+    closeCurrentTab: cmd(closeCurrentTab, "Buffer", "Close current tab", global),
+    reopenLastClosedTab: cmd(reopenLastClosedTab, "Buffer", "Reopen last closed tab", global),
+    switchToLastTab: cmd(switchToLastTab, "Buffer", "Switch to last tab", global),
+    previousTab: cmd(previousTab, "Buffer", "Switch to previous tab", global),
+    nextTab: cmd(nextTab, "Buffer", "Switch to next tab", global),
     ...Object.fromEntries(Array.from({ length: 9 }, (_, i) => [
         "switchToTab" + (i+1), 
         cmdLessContext(() => {
             useHeynoteStore().switchToTabIndex(i)
             return true
-        }, "Buffer", `Switch to tab ${i+1}`),
+        }, "Buffer", `Switch to tab ${i+1}`, global),
     ])),
 
     // spellcheck
     toggleSpellcheck: cmd(toggleSpellcheck, "Spellchecker", "Toggle Spellchecking"),
     enableSpellcheck: cmd(enableSpellcheck, "Spellchecker", "Enable Spellchecking"),
     disableSpellcheck: cmd(disableSpellcheck, "Spellchecker", "Disable Spellchecking"),
-    toggleAlwaysOnTop: cmd(toggleAlwaysOnTop, "Window", "Toggle Always on top"),
+    toggleAlwaysOnTop: cmd(toggleAlwaysOnTop, "Window", "Toggle Always on top", global),
 
     // commands without editor context
     paste: cmdLessContext(pasteCommand, "Clipboard", "Paste from clipboard"),
@@ -199,7 +203,7 @@ const HEYNOTE_COMMANDS = {
     selectNextParagraph: cmdLessContext(selectNextParagraph, "Selection", "Select to next paragraph"),
     selectPreviousBlock: cmdLessContext(selectPreviousBlock, "Selection", "Select to previous block"),
     selectNextBlock: cmdLessContext(selectNextBlock, "Selection", "Select to next block"),
-    nothing: cmdLessContext(nothing, "Misc", "Do nothing"),
+    nothing: cmdLessContext(nothing, "Misc", "Do nothing", global),
     insertDateAndTime: cmdLessContext(insertDateAndTime, "Misc", "Insert date and time"),
     insertIndentation: cmdLessContext(insertIndentation, "Edit", "Insert indentation"),
 

--- a/src/editor/commands.js
+++ b/src/editor/commands.js
@@ -110,6 +110,13 @@ export function toggleLeftPanel(editor) {
     }
 }
 
+export function openBufferExplorer(editor) {
+    return (view) => {
+        useHeynoteStore().openBufferExplorer()
+        return true
+    }
+}
+
 export function openLibrarySearch(editor) {
     return (view) => {
         useHeynoteStore().openLibrarySearch()
@@ -166,6 +173,7 @@ const HEYNOTE_COMMANDS = {
     unfoldBlock: cmd(unfoldBlock, "Block", "Unfold block"),
     toggleBlockFold: cmd(toggleBlockFold, "Block", "Toggle block fold"),
     toggleLeftPanel: cmd(toggleLeftPanel, "Editor", "Toggle left sidebar panel", global),
+    openBufferExplorer: cmd(openBufferExplorer, "Buffer", "Open buffer explorer", global),
     openLibrarySearch: cmd(openLibrarySearch, "Search", "Open library search", global),
 
     // tab commands

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -286,6 +286,30 @@ export class HeynoteEditor {
         })
     }
 
+    setCursorPositionAtLineColumn(lineNumber, column=0) {
+        if (!Number.isInteger(lineNumber)) {
+            return
+        }
+
+        const line = this.view.state.doc.line(Math.max(1, Math.min(lineNumber, this.view.state.doc.lines)))
+        const position = Math.max(line.from, Math.min(line.to, line.from + Math.max(0, column)))
+        this.setCursorPosition(position)
+    }
+
+    setSelectionAtLineColumns(lineNumber, fromColumn=0, toColumn=fromColumn) {
+        if (!Number.isInteger(lineNumber)) {
+            return
+        }
+
+        const line = this.view.state.doc.line(Math.max(1, Math.min(lineNumber, this.view.state.doc.lines)))
+        const from = Math.max(line.from, Math.min(line.to, line.from + Math.max(0, fromColumn)))
+        const to = Math.max(line.from, Math.min(line.to, line.from + Math.max(0, toColumn)))
+        this.view.dispatch({
+            selection: {anchor: from, head: to},
+            scrollIntoView: true,
+        })
+    }
+
     focus() {
         this.view.focus()
     }

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -138,6 +138,7 @@ export const DEFAULT_KEYMAP = [
 
     // sidebar
     cmd("Mod-Shift-e", "toggleLeftPanel"),
+    cmd("Mod-Shift-f", "openLibrarySearch"),
 
     // search
     //cmd("Mod-f", "openSearchPanel"),
@@ -298,7 +299,7 @@ export function getAllKeyBindingsForCommand(command, keymapName, userKeymap, ema
     const capturingCommands = new Set([
         "nothing", 
         "toggleAlwaysOnTop", 
-        "toggleLeftPanel",
+        "toggleLeftPanel", "openLibrarySearch",
         "openLanguageSelector", "openBufferSelector", "openCreateNewBuffer", "openMoveToBuffer", "openCommandPalette", 
         "closeCurrentTab", "reopenLastClosedTab", "nextTab", "previousTab", 
         "switchToTab1", "switchToTab2", "switchToTab3", "switchToTab4", "switchToTab5", "switchToTab6", "switchToTab7", "switchToTab8", "switchToTab9", "switchToLastTab"

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -137,7 +137,7 @@ export const DEFAULT_KEYMAP = [
     cmd("Mod-0", "switchToLastTab"),
 
     // sidebar
-    cmd("Mod-Shift-e", "toggleLeftPanel"),
+    cmd("Mod-Shift-e", "openBufferExplorer"),
     cmd("Mod-Shift-f", "openLibrarySearch"),
 
     // search
@@ -303,7 +303,7 @@ export function getAllKeyBindingsForCommand(command, keymapName, userKeymap, ema
     const capturingCommands = new Set([
         "nothing", 
         "toggleAlwaysOnTop", 
-        "toggleLeftPanel", "openLibrarySearch",
+        "toggleLeftPanel", "openBufferExplorer", "openLibrarySearch",
         "openLanguageSelector", "openBufferSelector", "openCreateNewBuffer", "openMoveToBuffer", "openCommandPalette", 
         "closeCurrentTab", "reopenLastClosedTab", "nextTab", "previousTab", 
         "switchToTab1", "switchToTab2", "switchToTab3", "switchToTab4", "switchToTab5", "switchToTab6", "switchToTab7", "switchToTab8", "switchToTab9", "switchToLastTab"

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -137,6 +137,7 @@ export const DEFAULT_KEYMAP = [
     cmd("Mod-0", "switchToLastTab"),
 
     // sidebar
+    cmd("Mod-Shift-s", "toggleLeftPanel"),
     cmd("Mod-Shift-e", "openBufferExplorer"),
     cmd("Mod-Shift-f", "openLibrarySearch"),
 

--- a/src/editor/keymap.js
+++ b/src/editor/keymap.js
@@ -193,20 +193,24 @@ function keymapFromSpec(specs, editor) {
         if (key.indexOf("EmacsMeta") != -1) {
             key = key.replace("EmacsMeta", editor.emacsMetaKey === "alt" ? "Alt" : "Meta")
         }
+        const command = HEYNOTE_COMMANDS[spec.command]
+        const scopes = spec.scope ? spec.scope.split(" ") : ["editor"]
+        if (command?.global) {
+            scopes.push("global")
+        }
         return {
             key: key,
             //preventDefault: true,
             preventDefault: false,
             run: (view) => {
                 //console.log("run()", spec.key, spec.command)
-                const command = HEYNOTE_COMMANDS[spec.command]
                 if (!command) {
                     console.error(`Command not found: ${spec.command} (${spec.key})`)
                     return false
                 }
                 return command.run(editor)(view)
             },
-            scope: spec.scope,
+            scope: [...new Set(scopes)].join(" "),
         }
     }))
 }

--- a/src/editor/search/InputToggle.vue
+++ b/src/editor/search/InputToggle.vue
@@ -4,6 +4,7 @@
         props: {
             modelValue: Boolean,
             type: String,
+            disabled: Boolean,
         },
         emits: ["update:modelValue"],
 
@@ -16,6 +17,7 @@
                 return {
                     "input-toggle": true,
                     active: this.modelValue,
+                    disabled: this.disabled,
                     "block": this.type === "block",
                     "case-sensitive": this.type === "case-sensitive",
                     "whole-words": this.type === "whole-words",
@@ -53,6 +55,7 @@
     <button
         :class="className"
         :title="title"
+        :disabled="disabled"
         @click="toggle"
     >
         <slot></slot>
@@ -76,6 +79,11 @@
             background-color: rgba(0,0,0, 0.1)
             +dark-mode
                 background-color: rgba(255,255,255, 0.15)
+        &.disabled
+            cursor: default
+            opacity: 0.45
+            &:hover
+                background-color: transparent
         
         &.active
             background-color: #DFF1E9

--- a/src/stores/editor-cache.js
+++ b/src/stores/editor-cache.js
@@ -24,7 +24,7 @@ export const useEditorCacheStore = defineStore("editorCache", {
     }),
 
     actions: {
-        _createEditorInstance(path) {
+        _createEditorInstance(path, options = {}) {
             const settingsStore = useSettingsStore()
             const errorStore = useErrorStore()
             let editor
@@ -48,6 +48,7 @@ export const useEditorCacheStore = defineStore("editorCache", {
                     spellcheckEnabled: settingsStore.settings.spellcheckEnabled,
                     showWhitespace: settingsStore.settings.showWhitespace,
                     cursorBlinkRate: settingsStore.settings.cursorBlinkRate,
+                    focus: options.focus !== false,
                 })
             } catch (e) {
                 errorStore.addError("Error! " + e.message)
@@ -57,13 +58,13 @@ export const useEditorCacheStore = defineStore("editorCache", {
             return editor
         },
 
-        getOrCreateEditor(path) {
+        getOrCreateEditor(path, options = {}) {
             if (this.cache[path]) {
                 this.updateLru(path)
                 this.freeStaleEditors()
                 return [this.cache[path], false]
             } else {
-                const editor = this._createEditorInstance(path)
+                const editor = this._createEditorInstance(path, options)
                 this.cache[path] = editor
 
                 // add the editor to the LRU

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -45,6 +45,7 @@ export const useHeynoteStore = defineStore("heynote", {
 
         showLeftPanel: window.heynote.settings.showLeftPanel ?? false,
         leftPanelWidth: window.heynote.settings.leftPanelWidth ?? 220,
+        currentLeftPanel: "buffer-tree",
         isFullscreen: false,
         isFocused: true,
         systemLocale: navigator.language,

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -20,6 +20,8 @@ export const useHeynoteStore = defineStore("heynote", {
 
         currentEditor: null,
         currentBufferPath: null,
+        // One-shot focus request consumed by Editor.vue when a buffer load actually happens.
+        focusEditorOnBufferOpen: true,
         currentBufferName: null,
         currentLanguage: null,
         currentLanguageAuto: null,
@@ -113,8 +115,25 @@ export const useHeynoteStore = defineStore("heynote", {
             this.focusEditor()
         },
 
-        openBuffer(path) {
+        consumeFocusEditorOnBufferOpen() {
+            const focusEditor = this.focusEditorOnBufferOpen
+            this.focusEditorOnBufferOpen = true
+            return focusEditor
+        },
+
+        openBuffer(path, options = {}) {
             this.closeDialog()
+            const focusEditor = options.focusEditor !== false
+
+            // Same-buffer opens do not trigger Editor.vue to consume this flag.
+            if (path === this.currentBufferPath) {
+                this.focusEditorOnBufferOpen = true
+                if (focusEditor) {
+                    this.focusEditor()
+                }
+            } else {
+                this.focusEditorOnBufferOpen = focusEditor
+            }
             this.currentBufferPath = path
             this.addRecentBuffer(path)
 

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -45,7 +45,7 @@ export const useHeynoteStore = defineStore("heynote", {
         drawImageUrl: null,
         drawImageId: null,
 
-        showLeftPanel: window.heynote.settings.showLeftPanel ?? false,
+        showLeftPanel: window.heynote.settings.showLeftPanel ?? true,
         leftPanelWidth: window.heynote.settings.leftPanelWidth ?? 250,
         currentLeftPanel: "buffer-tree",
         hideLeftPanelOnLibrarySearchEscape: false,

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -48,6 +48,7 @@ export const useHeynoteStore = defineStore("heynote", {
         currentLeftPanel: "buffer-tree",
         hideLeftPanelOnLibrarySearchEscape: false,
         librarySearchFocusRequestId: 0,
+        bufferTreeFocusRequestId: 0,
         isFullscreen: false,
         isFocused: true,
         systemLocale: navigator.language,
@@ -80,6 +81,17 @@ export const useHeynoteStore = defineStore("heynote", {
 
         toggleLeftPanel() {
             this.setLeftPanelVisible(!this.showLeftPanel, true)
+        },
+
+        openBufferExplorer() {
+            if (document.activeElement?.closest?.(".buffer-tree")) {
+                this.focusEditor()
+                return
+            }
+            this.closeDialog()
+            this.setLeftPanelVisible(true, true)
+            this.currentLeftPanel = "buffer-tree"
+            this.bufferTreeFocusRequestId++
         },
 
         openLibrarySearch() {

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -51,6 +51,7 @@ export const useHeynoteStore = defineStore("heynote", {
         hideLeftPanelOnLibrarySearchEscape: false,
         librarySearchFocusRequestId: 0,
         bufferTreeFocusRequestId: 0,
+        focusBufferTreeOnMount: false,
         isFullscreen: false,
         isFocused: true,
         systemLocale: navigator.language,
@@ -91,6 +92,7 @@ export const useHeynoteStore = defineStore("heynote", {
                 return
             }
             this.closeDialog()
+            this.focusBufferTreeOnMount = true
             this.setLeftPanelVisible(true, true)
             this.currentLeftPanel = "buffer-tree"
             this.bufferTreeFocusRequestId++
@@ -113,6 +115,12 @@ export const useHeynoteStore = defineStore("heynote", {
                 this.currentLeftPanel = "buffer-tree"
             }
             this.focusEditor()
+        },
+
+        consumeFocusBufferTreeOnMount() {
+            const focusBufferTree = this.focusBufferTreeOnMount
+            this.focusBufferTreeOnMount = false
+            return focusBufferTree
         },
 
         consumeFocusEditorOnBufferOpen() {

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -1,4 +1,4 @@
-import { toRaw, nextTick, watch } from 'vue';
+import { toRaw, watch } from 'vue';
 import { defineStore } from "pinia"
 import { NoteFormat } from "../common/note-format"
 import { toSafeBrowserLocale } from "../util/locale.js"
@@ -46,6 +46,8 @@ export const useHeynoteStore = defineStore("heynote", {
         showLeftPanel: window.heynote.settings.showLeftPanel ?? false,
         leftPanelWidth: window.heynote.settings.leftPanelWidth ?? 220,
         currentLeftPanel: "buffer-tree",
+        hideLeftPanelOnLibrarySearchEscape: false,
+        librarySearchFocusRequestId: 0,
         isFullscreen: false,
         isFocused: true,
         systemLocale: navigator.language,
@@ -78,6 +80,25 @@ export const useHeynoteStore = defineStore("heynote", {
 
         toggleLeftPanel() {
             this.setLeftPanelVisible(!this.showLeftPanel, true)
+        },
+
+        openLibrarySearch() {
+            const wasLeftPanelVisible = this.showLeftPanel
+            this.closeDialog()
+            this.hideLeftPanelOnLibrarySearchEscape = !wasLeftPanelVisible
+            this.setLeftPanelVisible(true, true)
+            this.currentLeftPanel = "search"
+            this.librarySearchFocusRequestId++
+        },
+
+        closeLibrarySearchFromEscape() {
+            if (this.hideLeftPanelOnLibrarySearchEscape) {
+                this.hideLeftPanelOnLibrarySearchEscape = false
+                this.setLeftPanelVisible(false, true)
+            } else {
+                this.currentLeftPanel = "buffer-tree"
+            }
+            this.focusEditor()
         },
 
         openBuffer(path) {

--- a/src/stores/heynote-store.js
+++ b/src/stores/heynote-store.js
@@ -46,7 +46,7 @@ export const useHeynoteStore = defineStore("heynote", {
         drawImageId: null,
 
         showLeftPanel: window.heynote.settings.showLeftPanel ?? false,
-        leftPanelWidth: window.heynote.settings.leftPanelWidth ?? 220,
+        leftPanelWidth: window.heynote.settings.leftPanelWidth ?? 250,
         currentLeftPanel: "buffer-tree",
         hideLeftPanelOnLibrarySearchEscape: false,
         librarySearchFocusRequestId: 0,

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -97,8 +97,10 @@ export const useSearchStore = defineStore("search", {
             }
             this.results[resultIndex].matches.push({
                 line: match.line,
+                displayLine: match.displayLine,
                 lineNumber: match.lineNumber,
                 submatches: match.submatches || [],
+                displaySubmatches: match.displaySubmatches || [],
             })
         },
 

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -1,32 +1,143 @@
 import { defineStore } from 'pinia'
+import {
+    LIBRARY_SEARCH_CANCEL,
+    LIBRARY_SEARCH_DONE,
+    LIBRARY_SEARCH_ERROR,
+    LIBRARY_SEARCH_MATCH,
+    LIBRARY_SEARCH_START,
+} from "@/src/common/constants"
 
 export const useSearchStore = defineStore("search", {
     state: () => ({
         results: [],
+        resultBufferIndex: {},
         query: "",
         caseSensitive: true,
         wholeWord: false,
         regexp: false,
+        searching: false,
+        error: null,
+        searchId: 0,
+        listenersInitialized: false,
+        pendingMatches: [],
+        flushScheduled: false,
     }),
 
     actions: {
+        initializeSearchListeners() {
+            if (this.listenersInitialized) {
+                return
+            }
+            this.listenersInitialized = true
+            window.heynote.mainProcess.on(LIBRARY_SEARCH_MATCH, (event, match) => {
+                if (match.searchId !== this.searchId) {
+                    return
+                }
+                this.queueMatch(match)
+            })
+            window.heynote.mainProcess.on(LIBRARY_SEARCH_DONE, (event, payload) => {
+                if (payload.searchId !== this.searchId) {
+                    return
+                }
+                this.flushPendingMatches()
+                this.searching = false
+            })
+            window.heynote.mainProcess.on(LIBRARY_SEARCH_ERROR, (event, payload) => {
+                if (payload.searchId !== this.searchId) {
+                    return
+                }
+                this.flushPendingMatches()
+                this.searching = false
+                this.error = payload.message || "Search failed"
+            })
+        },
+
+        // Queue streamed ripgrep matches and flush them at most once per frame so
+        // large result sets do not trigger a Vue update for every single match.
+        queueMatch(match) {
+            this.pendingMatches.push(match)
+            if (this.flushScheduled) {
+                return
+            }
+            this.flushScheduled = true
+            window.requestAnimationFrame(() => {
+                this.flushScheduled = false
+                this.flushPendingMatches()
+            })
+        },
+
+        // Move queued matches into the rendered result tree, ignoring stale
+        // matches from searches that have since been cancelled or replaced.
+        flushPendingMatches() {
+            if (this.pendingMatches.length === 0) {
+                return
+            }
+            const matches = this.pendingMatches
+            this.pendingMatches = []
+            for (const match of matches) {
+                if (match.searchId !== this.searchId) {
+                    continue
+                }
+                this.addMatch(match)
+            }
+        },
+
+        // Insert one match into the grouped result structure used by the tree UI.
+        // Each buffer gets one top-level result item containing all its row matches.
+        addMatch(match) {
+            let resultIndex = this.resultBufferIndex[match.buffer]
+            if (resultIndex === undefined) {
+                resultIndex = this.results.length
+                this.resultBufferIndex[match.buffer] = resultIndex
+                this.results.push({
+                    buffer: match.buffer,
+                    matches: [],
+                })
+            }
+            this.results[resultIndex].matches.push({
+                line: match.line,
+                lineNumber: match.lineNumber,
+                submatches: match.submatches || [],
+            })
+        },
+
         search(query) {
+            this.initializeSearchListeners()
             this.query = query
-            this.results = [
-                {
-                    buffer: "scratch.txt",
-                    matches: [
-                        {line: "testing: " + query},
-                        {line: "another: " + query},
-                    ],
-                },
-                {
-                    buffer: "subdir/another.txt",
-                    matches: [
-                        {line: "tesssst: " + query},
-                    ],
-                },
-            ]
+            this.searchId++
+            this.results = []
+            this.resultBufferIndex = {}
+            this.pendingMatches = []
+            this.error = null
+
+            if (query.trim().length <= 2) {
+                this.searching = false
+                Promise.resolve(window.heynote.mainProcess.invoke(LIBRARY_SEARCH_CANCEL)).catch(() => {})
+                return
+            }
+
+            const searchId = this.searchId
+            this.searching = true
+            Promise.resolve(window.heynote.mainProcess.invoke(LIBRARY_SEARCH_START, {
+                searchId,
+                query,
+                caseSensitive: this.caseSensitive,
+                wholeWord: this.wholeWord,
+                regexp: false,
+            })).catch((error) => {
+                if (searchId !== this.searchId) {
+                    return
+                }
+                this.searching = false
+                this.error = error.message || "Search failed"
+            })
+        },
+
+        cancelActiveSearch() {
+            this.searchId++
+            this.searching = false
+            this.pendingMatches = []
+            Promise.resolve(window.heynote.mainProcess.invoke(LIBRARY_SEARCH_CANCEL)).catch(() => {})
         },
     },
 })

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -7,22 +7,34 @@ import {
     LIBRARY_SEARCH_START,
 } from "@/src/common/constants"
 
+const defaultLibrarySearchSettings = {
+    caseSensitive: false,
+    wholeWord: false,
+    regexp: false,
+}
+
 export const useSearchStore = defineStore("search", {
-    state: () => ({
-        results: [],
-        resultBufferIndex: {},
-        query: "",
-        caseSensitive: true,
-        wholeWord: false,
-        regexp: false,
-        searching: false,
-        error: null,
-        searchId: 0,
-        listenersInitialized: false,
-        pendingMatches: [],
-        flushScheduled: false,
-        selectedResultRow: null,
-    }),
+    state: () => {
+        const librarySearchSettings = {
+            ...defaultLibrarySearchSettings,
+            ...(window.heynote.settings.librarySearchSettings || {}),
+        }
+        return {
+            results: [],
+            resultBufferIndex: {},
+            query: "",
+            caseSensitive: librarySearchSettings.caseSensitive === true,
+            wholeWord: librarySearchSettings.wholeWord === true,
+            regexp: librarySearchSettings.regexp === true,
+            searching: false,
+            error: null,
+            searchId: 0,
+            listenersInitialized: false,
+            pendingMatches: [],
+            flushScheduled: false,
+            selectedResultRow: null,
+        }
+    },
 
     actions: {
         initializeSearchListeners() {

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia'
+
+export const useSearchStore = defineStore("search", {
+    state: () => ({
+        results: [],
+        query: "",
+        caseSensitive: true,
+        wholeWord: false,
+        regexp: false,
+    }),
+
+    actions: {
+        search(query) {
+            this.query = query
+            this.results = [
+                {
+                    buffer: "scratch.txt",
+                    matches: [
+                        {line: "testing: " + query},
+                        {line: "another: " + query},
+                    ],
+                },
+                {
+                    buffer: "other.txt",
+                    matches: [
+                        {line: "tesssst: " + query},
+                    ],
+                },
+            ]
+        },
+    },
+})

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -147,7 +147,7 @@ export const useSearchStore = defineStore("search", {
                 query,
                 caseSensitive: this.caseSensitive,
                 wholeWord: this.wholeWord,
-                regexp: false,
+                regexp: this.regexp,
             })).catch((error) => {
                 if (searchId !== this.searchId) {
                     return

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -21,6 +21,7 @@ export const useSearchStore = defineStore("search", {
         listenersInitialized: false,
         pendingMatches: [],
         flushScheduled: false,
+        selectedResultRow: null,
     }),
 
     actions: {
@@ -101,6 +102,26 @@ export const useSearchStore = defineStore("search", {
             })
         },
 
+        selectResultRow(row) {
+            this.selectedResultRow = row
+        },
+
+        selectMatch(match) {
+            this.selectResultRow({
+                type: "match",
+                buffer: match.buffer,
+                lineNumber: match.lineNumber,
+                line: match.line,
+            })
+        },
+
+        selectBuffer(buffer) {
+            this.selectResultRow({
+                type: "buffer",
+                buffer,
+            })
+        },
+
         search(query) {
             this.initializeSearchListeners()
             this.query = query
@@ -108,6 +129,7 @@ export const useSearchStore = defineStore("search", {
             this.results = []
             this.resultBufferIndex = {}
             this.pendingMatches = []
+            this.selectedResultRow = null
             this.error = null
 
             if (query.trim().length <= 2) {
@@ -137,6 +159,7 @@ export const useSearchStore = defineStore("search", {
             this.searchId++
             this.searching = false
             this.pendingMatches = []
+            this.selectedResultRow = null
             Promise.resolve(window.heynote.mainProcess.invoke(LIBRARY_SEARCH_CANCEL)).catch(() => {})
         },
     },

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -21,7 +21,7 @@ export const useSearchStore = defineStore("search", {
                     ],
                 },
                 {
-                    buffer: "other.txt",
+                    buffer: "subdir/another.txt",
                     matches: [
                         {line: "tesssst: " + query},
                     ],

--- a/tests/main/ripgrep.test.js
+++ b/tests/main/ripgrep.test.js
@@ -101,6 +101,42 @@ describe("startLibrarySearch", () => {
         })
     })
 
+    it("supports regex matching when enabled", async () => {
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            "literal a.b\nregex-looking axb\nregex-looking ayb\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 457,
+            query: "a.b",
+            caseSensitive: true,
+            wholeWord: false,
+            regexp: true,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(3)
+        expect(matches.map((match) => match.line)).toEqual([
+            "literal a.b",
+            "regex-looking axb",
+            "regex-looking ayb",
+        ])
+    })
+
+    it("reports invalid regex errors", async () => {
+        await fs.promises.writeFile(path.join(tmpDir, "scratch.txt"), "content\n", "utf8")
+
+        await expect(runLibrarySearch(tmpDir, {
+            searchId: 458,
+            query: "[",
+            caseSensitive: true,
+            wholeWord: false,
+            regexp: true,
+        })).rejects.toThrow()
+    })
+
     it("reports submatch offsets as JavaScript string indexes", async () => {
         const line = "🙂🙂 foobar 🙂 foo"
         await fs.promises.writeFile(

--- a/tests/main/ripgrep.test.js
+++ b/tests/main/ripgrep.test.js
@@ -1,0 +1,126 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { startLibrarySearch } from "../../electron/main/ripgrep.js"
+
+const makeTempDir = () =>
+    fs.mkdtempSync(path.join(os.tmpdir(), "heynote-ripgrep-"))
+
+function runLibrarySearch(basePath, options) {
+    const events = []
+    return new Promise((resolve, reject) => {
+        startLibrarySearch({ basePath }, options, (payload) => {
+            events.push(payload)
+            if (payload.type === "error") {
+                reject(new Error(payload.message))
+            } else if (payload.type === "done") {
+                resolve(events)
+            }
+        })
+    })
+}
+
+describe("startLibrarySearch", () => {
+    let tmpDir = ""
+
+    beforeEach(() => {
+        tmpDir = makeTempDir()
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it("streams fixed-string JSON matches grouped by note file", async () => {
+        await fs.promises.mkdir(path.join(tmpDir, "subdir"))
+        await fs.promises.mkdir(path.join(tmpDir, ".images"))
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            "Needle one\naxb should not match\nliteral a.b\n",
+            "utf8"
+        )
+        await fs.promises.writeFile(
+            path.join(tmpDir, "subdir", "note.txt"),
+            "second needle\n",
+            "utf8"
+        )
+        await fs.promises.writeFile(
+            path.join(tmpDir, ".images", "ignored.txt"),
+            "needle in hidden image dir\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 123,
+            query: "needle",
+            caseSensitive: false,
+            wholeWord: false,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(2)
+        expect(matches).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                searchId: 123,
+                buffer: "scratch.txt",
+                line: "Needle one",
+                lineNumber: 1,
+            }),
+            expect.objectContaining({
+                searchId: 123,
+                buffer: path.join("subdir", "note.txt"),
+                line: "second needle",
+                lineNumber: 1,
+            }),
+        ]))
+    })
+
+    it("uses fixed-string matching instead of regex matching", async () => {
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            "literal a.b\nregex-looking axb\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 456,
+            query: "a.b",
+            caseSensitive: true,
+            wholeWord: false,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(1)
+        expect(matches[0]).toMatchObject({
+            buffer: "scratch.txt",
+            line: "literal a.b",
+            lineNumber: 1,
+        })
+    })
+
+    it("reports submatch offsets as JavaScript string indexes", async () => {
+        const line = "🙂🙂 foobar 🙂 foo"
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            line + "\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 789,
+            query: "foo",
+            caseSensitive: true,
+            wholeWord: true,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(1)
+        expect(matches[0].submatches).toHaveLength(1)
+        const [submatch] = matches[0].submatches
+        expect(line.slice(submatch.start, submatch.end)).toBe("foo")
+        expect(submatch.start).toBe(line.lastIndexOf("foo"))
+    })
+})

--- a/tests/main/ripgrep.test.js
+++ b/tests/main/ripgrep.test.js
@@ -125,6 +125,30 @@ describe("startLibrarySearch", () => {
         ])
     })
 
+    it("supports PCRE2-only regex features when regex matching is enabled", async () => {
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            "ticket-123\nticket-abc\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 459,
+            query: "ticket-(?=\\d+)",
+            caseSensitive: true,
+            wholeWord: false,
+            regexp: true,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(1)
+        expect(matches[0]).toMatchObject({
+            buffer: "scratch.txt",
+            line: "ticket-123",
+            lineNumber: 1,
+        })
+    })
+
     it("reports invalid regex errors", async () => {
         await fs.promises.writeFile(path.join(tmpDir, "scratch.txt"), "content\n", "utf8")
 

--- a/tests/main/ripgrep.test.js
+++ b/tests/main/ripgrep.test.js
@@ -123,4 +123,44 @@ describe("startLibrarySearch", () => {
         expect(line.slice(submatch.start, submatch.end)).toBe("foo")
         expect(submatch.start).toBe(line.lastIndexOf("foo"))
     })
+
+    it("ignores Heynote metadata, block delimiters, and tags", async () => {
+        const tag = "<∞img;id=1;file=https://example.com/needle.png;w=10;h=10∞>"
+        const content = [
+            JSON.stringify({ formatVersion: "2.0.0", name: "Needle Metadata" }),
+            "∞∞∞text-a;created=2026-01-01T00:00:00.000Z",
+            `visible needle ${tag} tail`,
+            "∞∞∞markdown",
+            "after delimiter",
+        ].join("\n")
+        await fs.promises.writeFile(path.join(tmpDir, "scratch.txt"), content, "utf8")
+
+        const needleEvents = await runLibrarySearch(tmpDir, {
+            searchId: 1001,
+            query: "needle",
+            caseSensitive: false,
+            wholeWord: false,
+        })
+        const needleMatches = needleEvents.filter((event) => event.type === "match")
+
+        expect(needleMatches).toHaveLength(1)
+        expect(needleMatches[0]).toMatchObject({
+            buffer: "scratch.txt",
+            line: `visible needle ${tag} tail`,
+            displayLine: "visible needle  tail",
+            lineNumber: 3,
+            submatches: [{ start: 8, end: 14, text: "needle" }],
+            displaySubmatches: [{ start: 8, end: 14, text: "needle" }],
+        })
+
+        for (const query of ["metadata", "created", "markdown", "needle.png"]) {
+            const events = await runLibrarySearch(tmpDir, {
+                searchId: 1002,
+                query,
+                caseSensitive: false,
+                wholeWord: false,
+            })
+            expect(events.filter((event) => event.type === "match")).toHaveLength(0)
+        }
+    })
 })

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -119,6 +119,22 @@ test.describe("library search", () => {
         await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
     })
 
+    test("runs custom global key bindings while the search input is focused", async ({ page }) => {
+        await page.evaluate(() => {
+            const settings = JSON.parse(window.localStorage.getItem("settings") || "{}")
+            settings.keyBindings = [{key: "Ctrl-Shift-h", command: "openCommandPalette"}]
+            window.heynote.setSettings(settings)
+        })
+
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+        await expect(input).toBeFocused()
+
+        await input.press("Control+Shift+H")
+        await expect(page.locator(".note-selector .input-container input")).toHaveValue(">")
+        await expect(page.locator(".note-selector .items > li.selected")).toBeVisible()
+    })
+
     test("keeps the sidebar visible on Escape after switching away from library search", async ({ page }) => {
         await page.locator(".status .status-block.sidebar").click()
         await expect(page.locator(".left-panel")).toHaveCount(0)

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -314,7 +314,21 @@ test.describe("library search", () => {
         await input.fill("needle")
         await expect(input).toBeFocused()
 
+        await page.evaluate(() => {
+            window.__heynoteTestLastGlobalShortcut = null
+            window.addEventListener("keydown", (event) => {
+                if (event.key.toLowerCase() === "h" && event.ctrlKey && event.shiftKey) {
+                    window.__heynoteTestLastGlobalShortcut = {
+                        defaultPrevented: event.defaultPrevented,
+                    }
+                }
+            })
+        })
+
         await input.press("Control+Shift+H")
+        await expect.poll(() => page.evaluate(() => window.__heynoteTestLastGlobalShortcut)).toEqual({
+            defaultPrevented: true,
+        })
         await expect(page.locator(".note-selector .input-container input")).toHaveValue(">")
         await expect(page.locator(".note-selector .items > li.selected")).toBeVisible()
     })

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test"
+import { HeynotePage } from "./test-utils.js"
+
+function createBufferContent(name, content = "") {
+    return JSON.stringify({
+        formatVersion: "2.0.0",
+        name,
+    }) + `\n∞∞∞text-a;created=2026-01-01T00:00:00.000Z\n${content}`
+}
+
+function installLibraryState() {
+    const settings = {
+        showLeftPanel: true,
+        leftPanelWidth: 260,
+    }
+    const notes = {
+        "scratch.txt": createBufferContent("Scratch", [
+            "first needle match",
+            "second needle match",
+            "short non-match",
+        ].join("\n")),
+        "folder-a/project.txt": createBufferContent("Project Note", [
+            "emoji context 🙂🙂🙂 and a long prefix before the important needle match",
+            "another non-match",
+        ].join("\n")),
+        "folder-a/other.txt": createBufferContent("Other Note", "nothing to find here"),
+    }
+    return { settings, notes }
+}
+
+test.describe("library search", () => {
+    test.beforeEach(async ({ page }) => {
+        const state = installLibraryState()
+        await page.addInitScript((seed) => {
+            localStorage.clear()
+            localStorage.setItem("settings", JSON.stringify(seed.settings))
+            for (const [path, content] of Object.entries(seed.notes)) {
+                localStorage.setItem(`heynote-library__${path}`, content)
+            }
+        }, state)
+
+        const heynotePage = new HeynotePage(page)
+        await heynotePage.goto()
+        await page.getByRole("button", { name: "Search" }).click()
+        await expect(page.locator(".search-container")).toBeVisible()
+    })
+
+    test("shows grouped results, counts, highlighting, and preview context", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+
+        await expect(page.locator(".result-summary")).toContainText("3 results in 2 buffers")
+        await expect(page.locator(".result-container")).toHaveCount(2)
+        await expect(page.locator(".result-container .buffer", { hasText: "Scratch" })).toBeVisible()
+        await expect(page.locator(".result-container .buffer", { hasText: "Project Note" })).toBeVisible()
+
+        await expect(page.locator(".result-container .match")).toHaveCount(3)
+        await expect(page.locator(".result-container .match strong", { hasText: "needle" })).toHaveCount(3)
+
+        const longMatchText = page.locator(".result-container .match", { hasText: "important" })
+        await expect(longMatchText).toContainText("...g prefix before the important needle match")
+        await expect(longMatchText.locator("strong")).toHaveText("needle")
+    })
+
+    test("collapses and expands matches for a buffer", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+        const scratchResult = page.locator(".result-container", { hasText: "Scratch" })
+
+        await expect(scratchResult.locator(".match")).toHaveCount(2)
+        await scratchResult.locator(".buffer").click()
+        await expect(scratchResult.locator(".match")).toHaveCount(0)
+        await scratchResult.locator(".buffer").click()
+        await expect(scratchResult.locator(".match")).toHaveCount(2)
+    })
+
+    test("hides result summary and rows when the query is cleared", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+        await expect(page.locator(".result-summary")).toBeVisible()
+
+        await input.fill("")
+        await expect(page.locator(".result-summary")).toHaveCount(0)
+        await expect(page.locator(".result-container")).toHaveCount(0)
+    })
+
+    test("shows indentation guides when the sidebar is hovered", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+
+        const guide = page.locator(".result-container .match .indent-guide").first()
+        await expect(guide).toHaveCount(1)
+
+        await page.mouse.move(500, 200)
+        await expect.poll(async () => {
+            return await guide.evaluate((element) => window.getComputedStyle(element).opacity)
+        }).toBe("0")
+
+        await page.locator(".left-panel").hover()
+        await expect.poll(async () => {
+            return await guide.evaluate((element) => window.getComputedStyle(element).opacity)
+        }).toBe("1")
+    })
+})

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -212,6 +212,22 @@ test.describe("library search", () => {
         await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
     })
 
+    test("focuses the editor on Escape after an earlier buffer-tree focus request", async ({ page }) => {
+        await page.evaluate(() => {
+            window._heynote_editor.notesStore.openBufferExplorer()
+        })
+        await expect(page.locator(".buffer-tree")).toBeFocused()
+
+        await page.getByRole("button", { name: "Search" }).click()
+        const input = page.locator(".search-container input.search-query")
+        await expect(input).toBeFocused()
+
+        await input.press("Escape")
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+        await expect(page.locator(".buffer-tree")).not.toBeFocused()
+    })
+
     test("focuses the editor and switches to the Buffers tab when Escape is pressed on a focused result", async ({ page }) => {
         const input = page.locator(".search-container input.search-query")
         await input.fill("needle")

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -72,6 +72,52 @@ test.describe("library search", () => {
         await expect(scratchResult.locator(".match")).toHaveCount(2)
     })
 
+    test("supports keyboard focus and arrow navigation for result rows", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+        await expect(page.locator(".result-container .match")).toHaveCount(3)
+
+        const rows = page.locator(".search-result-row")
+        await expect(rows).toHaveCount(5)
+
+        await input.press("ArrowDown")
+        await expect(rows.nth(0)).toBeFocused()
+        await expect(rows.nth(0)).toHaveCSS("outline-style", "solid")
+
+        await rows.nth(0).press("ArrowDown")
+        await expect(rows.nth(1)).toBeFocused()
+
+        await rows.nth(1).press("ArrowDown")
+        await expect(rows.nth(2)).toBeFocused()
+
+        await rows.nth(2).press("ArrowDown")
+        await expect(rows.nth(3)).toBeFocused()
+
+        await rows.nth(3).press("ArrowUp")
+        await expect(rows.nth(2)).toBeFocused()
+    })
+
+    test("opens and closes result groups with left and right arrow keys", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+
+        const rows = page.locator(".search-result-row")
+        const firstResult = page.locator(".result-container").first()
+        await expect(firstResult.locator(".match")).not.toHaveCount(0)
+
+        await input.press("ArrowDown")
+        await expect(rows.nth(0)).toBeFocused()
+
+        await rows.nth(0).press("ArrowLeft")
+        await expect(firstResult.locator(".match")).toHaveCount(0)
+        await expect(rows.nth(0)).toHaveClass(/buffer/)
+        await expect(rows.nth(1)).toHaveClass(/buffer/)
+
+        await rows.nth(0).press("ArrowRight")
+        await expect(firstResult.locator(".match")).not.toHaveCount(0)
+        await expect(rows.nth(1)).toHaveClass(/match/)
+    })
+
     test("hides result summary and rows when the query is cleared", async ({ page }) => {
         const input = page.locator(".search-container input.search-query")
         await input.fill("needle")

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -15,7 +15,7 @@ function installLibraryState() {
     }
     const notes = {
         "scratch.txt": createBufferContent("Scratch", [
-            "first needle match",
+            "first needle match <∞img;id=search-test;file=https://example.com/needle.png;w=10;h=10∞>",
             "second needle match",
             "short non-match",
         ].join("\n")),
@@ -55,10 +55,21 @@ test.describe("library search", () => {
 
         await expect(page.locator(".result-container .match")).toHaveCount(3)
         await expect(page.locator(".result-container .match strong", { hasText: "needle" })).toHaveCount(3)
+        await expect(page.locator(".result-container .match", { hasText: "needle.png" })).toHaveCount(0)
 
         const longMatchText = page.locator(".result-container .match", { hasText: "important" })
         await expect(longMatchText).toContainText("...g prefix before the important needle match")
         await expect(longMatchText.locator("strong")).toHaveText("needle")
+    })
+
+    test("does not match Heynote syntax", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+
+        for (const query of ["Scratch", "created", "text-a", "needle.png"]) {
+            await input.fill(query)
+            await expect(page.locator(".result-container")).toHaveCount(0)
+            await expect(page.locator(".result-summary")).toContainText("0 results in 0 buffers")
+        }
     })
 
     test("collapses and expands matches for a buffer", async ({ page }) => {

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -72,29 +72,89 @@ test.describe("library search", () => {
         await expect(scratchResult.locator(".match")).toHaveCount(2)
     })
 
+    test("opens a match without focusing the editor and selects the match", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+
+        const match = page.locator(".result-container .match", { hasText: "important" })
+        await match.click()
+
+        await expect(page.locator(".cm-editor.cm-focused")).toHaveCount(0)
+        await expect(page.locator(".results")).toBeFocused()
+        await expect(match).toHaveClass(/selected/)
+        await expect.poll(async () => {
+            return await page.evaluate(() => window._heynote_editor.path)
+        }).toBe("folder-a/project.txt")
+        await expect.poll(async () => {
+            return await page.evaluate(() => {
+                const editor = window._heynote_editor
+                const selection = editor.view.state.selection.main
+                return editor.view.state.doc.sliceString(selection.from, selection.to)
+            })
+        }).toBe("needle")
+    })
+
+    test("does not leak suppressed editor focus after opening a match in the current buffer", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+
+        const currentBufferMatch = page.locator(".result-container", { hasText: "Scratch" }).locator(".match", { hasText: "first" })
+        await currentBufferMatch.click()
+        await expect(page.locator(".results")).toBeFocused()
+        await expect(page.locator(".cm-editor.cm-focused")).toHaveCount(0)
+
+        await page.evaluate(() => {
+            const store = window._heynote_editor.notesStore
+            store.closedTabs = [{ path: "folder-a/project.txt", index: store.openTabs.length }]
+            store.reopenLastClosedTab()
+        })
+
+        await expect.poll(async () => {
+            return await page.evaluate(() => window._heynote_editor.path)
+        }).toBe("folder-a/project.txt")
+        await expect(page.locator(".cm-editor.cm-focused")).toHaveCount(1)
+    })
+
     test("supports keyboard focus and arrow navigation for result rows", async ({ page }) => {
         const input = page.locator(".search-container input.search-query")
         await input.fill("needle")
         await expect(page.locator(".result-container .match")).toHaveCount(3)
 
         const rows = page.locator(".search-result-row")
+        const results = page.locator(".results")
         await expect(rows).toHaveCount(5)
 
         await input.press("ArrowDown")
-        await expect(rows.nth(0)).toBeFocused()
+        await expect(results).toBeFocused()
+        await expect(rows.nth(0)).toHaveClass(/selected/)
         await expect(rows.nth(0)).toHaveCSS("outline-style", "solid")
 
-        await rows.nth(0).press("ArrowDown")
-        await expect(rows.nth(1)).toBeFocused()
+        await results.press("ArrowDown")
+        await expect(rows.nth(1)).toHaveClass(/selected/)
 
-        await rows.nth(1).press("ArrowDown")
-        await expect(rows.nth(2)).toBeFocused()
+        await results.press("ArrowDown")
+        await expect(rows.nth(2)).toHaveClass(/selected/)
 
-        await rows.nth(2).press("ArrowDown")
-        await expect(rows.nth(3)).toBeFocused()
+        await results.press("ArrowDown")
+        await expect(rows.nth(3)).toHaveClass(/selected/)
 
-        await rows.nth(3).press("ArrowUp")
-        await expect(rows.nth(2)).toBeFocused()
+        await results.press("ArrowUp")
+        await expect(rows.nth(2)).toHaveClass(/selected/)
+    })
+
+    test("does not include result rows in the tab order", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+        await expect(page.locator(".result-container .match")).toHaveCount(3)
+
+        const rows = page.locator(".search-result-row")
+        await input.press("Tab")
+        await expect.poll(async () => {
+            return await page.evaluate(() => document.activeElement?.classList.contains("search-result-row"))
+        }).toBe(false)
+
+        await input.focus()
+        await input.press("ArrowDown")
+        await expect(page.locator(".results")).toBeFocused()
+        await expect(rows.nth(0)).toHaveClass(/selected/)
     })
 
     test("opens and closes result groups with left and right arrow keys", async ({ page }) => {
@@ -102,18 +162,20 @@ test.describe("library search", () => {
         await input.fill("needle")
 
         const rows = page.locator(".search-result-row")
+        const results = page.locator(".results")
         const firstResult = page.locator(".result-container").first()
         await expect(firstResult.locator(".match")).not.toHaveCount(0)
 
         await input.press("ArrowDown")
-        await expect(rows.nth(0)).toBeFocused()
+        await expect(results).toBeFocused()
+        await expect(rows.nth(0)).toHaveClass(/selected/)
 
-        await rows.nth(0).press("ArrowLeft")
+        await results.press("ArrowLeft")
         await expect(firstResult.locator(".match")).toHaveCount(0)
         await expect(rows.nth(0)).toHaveClass(/buffer/)
         await expect(rows.nth(1)).toHaveClass(/buffer/)
 
-        await rows.nth(0).press("ArrowRight")
+        await results.press("ArrowRight")
         await expect(firstResult.locator(".match")).not.toHaveCount(0)
         await expect(rows.nth(1)).toHaveClass(/match/)
     })
@@ -135,6 +197,36 @@ test.describe("library search", () => {
 
         await input.press("Escape")
         await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+        await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
+    })
+
+    test("focuses the editor and switches to the Buffers tab when Escape is pressed on a focused result", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+
+        const rows = page.locator(".search-result-row")
+        const results = page.locator(".results")
+        await input.press("ArrowDown")
+        await results.press("ArrowDown")
+        await expect(results).toBeFocused()
+        await expect(rows.nth(1)).toHaveClass(/selected/)
+
+        await results.press("Escape")
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+        await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
+    })
+
+    test("focuses the editor when Escape is pressed after opening a match", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("needle")
+
+        const match = page.locator(".result-container .match", { hasText: "important" })
+        await match.click()
+        await expect(page.locator(".results")).toBeFocused()
+
+        await page.locator(".results").press("Escape")
+        await expect(page.locator(".cm-editor.cm-focused")).toHaveCount(1)
         await expect(page.locator(".buffer-tree")).toBeVisible()
         await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
     })

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -82,6 +82,15 @@ test.describe("library search", () => {
         await expect(page.locator(".result-container")).toHaveCount(0)
     })
 
+    test("focuses the editor when Escape is pressed in the search input", async ({ page }) => {
+        const input = page.locator(".search-container input.search-query")
+        await input.fill("needle")
+        await expect(input).toBeFocused()
+
+        await input.press("Escape")
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+    })
+
     test("shows indentation guides when the sidebar is hovered", async ({ page }) => {
         await page.locator(".search-container input.search-query").fill("needle")
 

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -58,7 +58,7 @@ test.describe("library search", () => {
         await expect(page.locator(".result-container .match", { hasText: "needle.png" })).toHaveCount(0)
 
         const longMatchText = page.locator(".result-container .match", { hasText: "important" })
-        await expect(longMatchText).toContainText("...g prefix before the important needle match")
+        await expect(longMatchText).toContainText("...efore the important needle match")
         await expect(longMatchText.locator("strong")).toHaveText("needle")
     })
 

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -34,10 +34,13 @@ test.describe("library search", () => {
     test.beforeEach(async ({ page }) => {
         const state = installLibraryState()
         await page.addInitScript((seed) => {
-            localStorage.clear()
-            localStorage.setItem("settings", JSON.stringify(seed.settings))
-            for (const [path, content] of Object.entries(seed.notes)) {
-                localStorage.setItem(`heynote-library__${path}`, content)
+            if (!sessionStorage.getItem("__heynoteLibrarySearchSeeded")) {
+                localStorage.clear()
+                localStorage.setItem("settings", JSON.stringify(seed.settings))
+                for (const [path, content] of Object.entries(seed.notes)) {
+                    localStorage.setItem(`heynote-library__${path}`, content)
+                }
+                sessionStorage.setItem("__heynoteLibrarySearchSeeded", "true")
             }
         }, state)
 
@@ -81,6 +84,35 @@ test.describe("library search", () => {
         await expect(page.locator(".result-summary")).toContainText("2 results in 2 buffers")
         await expect(page.locator(".result-container .match strong", { hasText: "issue-123" })).toHaveCount(1)
         await expect(page.locator(".result-container .match strong", { hasText: "issue-456" })).toHaveCount(1)
+    })
+
+    test("persists search setting toggles and defaults them to off", async ({ page }) => {
+        const caseSensitiveToggle = page.locator(".search-container .input-toggle.case-sensitive")
+        const wholeWordToggle = page.locator(".search-container .input-toggle.whole-words")
+        const regexToggle = page.locator(".search-container .input-toggle.regex")
+
+        await expect(caseSensitiveToggle).not.toHaveClass(/active/)
+        await expect(wholeWordToggle).not.toHaveClass(/active/)
+        await expect(regexToggle).not.toHaveClass(/active/)
+
+        await caseSensitiveToggle.click()
+        await wholeWordToggle.click()
+        await regexToggle.click()
+
+        await expect.poll(async () => {
+            return await page.evaluate(() => JSON.parse(window.localStorage.getItem("settings")).librarySearchSettings)
+        }).toEqual({
+            caseSensitive: true,
+            wholeWord: true,
+            regexp: true,
+        })
+
+        await page.reload()
+        await page.getByRole("button", { name: "Search" }).click()
+
+        await expect(page.locator(".search-container .input-toggle.case-sensitive")).toHaveClass(/active/)
+        await expect(page.locator(".search-container .input-toggle.whole-words")).toHaveClass(/active/)
+        await expect(page.locator(".search-container .input-toggle.regex")).toHaveClass(/active/)
     })
 
     test("shows invalid regular expression errors", async ({ page }) => {

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -82,13 +82,15 @@ test.describe("library search", () => {
         await expect(page.locator(".result-container")).toHaveCount(0)
     })
 
-    test("focuses the editor when Escape is pressed in the search input", async ({ page }) => {
+    test("focuses the editor and switches to the Buffers tab when Escape is pressed in the search input", async ({ page }) => {
         const input = page.locator(".search-container input.search-query")
         await input.fill("needle")
         await expect(input).toBeFocused()
 
         await input.press("Escape")
         await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+        await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
     })
 
     test("shows indentation guides when the sidebar is hovered", async ({ page }) => {

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -17,10 +17,12 @@ function installLibraryState() {
         "scratch.txt": createBufferContent("Scratch", [
             "first needle match <∞img;id=search-test;file=https://example.com/needle.png;w=10;h=10∞>",
             "second needle match",
+            "issue-123 is tracked",
             "short non-match",
         ].join("\n")),
         "folder-a/project.txt": createBufferContent("Project Note", [
             "emoji context 🙂🙂🙂 and a long prefix before the important needle match",
+            "issue-456 is done",
             "another non-match",
         ].join("\n")),
         "folder-a/other.txt": createBufferContent("Other Note", "nothing to find here"),
@@ -70,6 +72,23 @@ test.describe("library search", () => {
             await expect(page.locator(".result-container")).toHaveCount(0)
             await expect(page.locator(".result-summary")).toContainText("0 results in 0 buffers")
         }
+    })
+
+    test("supports regular expression searches", async ({ page }) => {
+        await page.locator(".search-container .input-toggle.regex").click()
+        await page.locator(".search-container input.search-query").fill("issue-\\d+")
+
+        await expect(page.locator(".result-summary")).toContainText("2 results in 2 buffers")
+        await expect(page.locator(".result-container .match strong", { hasText: "issue-123" })).toHaveCount(1)
+        await expect(page.locator(".result-container .match strong", { hasText: "issue-456" })).toHaveCount(1)
+    })
+
+    test("shows invalid regular expression errors", async ({ page }) => {
+        await page.locator(".search-container .input-toggle.regex").click()
+        await page.locator(".search-container input.search-query").fill("[invalid")
+
+        await expect(page.locator(".search-error")).toContainText("Invalid regular expression")
+        await expect(page.locator(".result-container")).toHaveCount(0)
     })
 
     test("collapses and expands matches for a buffer", async ({ page }) => {

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -93,6 +93,53 @@ test.describe("library search", () => {
         await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
     })
 
+    test("opens the search tab and left panel with the default keyboard shortcut", async ({ page }) => {
+        await page.locator(".status .status-block.sidebar").click()
+        await expect(page.locator(".left-panel")).toHaveCount(0)
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+
+        await page.locator("body").press("ControlOrMeta+Shift+F")
+
+        await expect(page.locator(".left-panel")).toBeVisible()
+        await expect(page.locator(".search-container")).toBeVisible()
+        await expect(page.getByRole("button", { name: "Search" })).toHaveClass(/selected/)
+        await expect(page.locator(".search-container input.search-query")).toBeFocused()
+    })
+
+    test("hides the sidebar on Escape when library search was opened from a hidden sidebar", async ({ page }) => {
+        await page.locator(".status .status-block.sidebar").click()
+        await expect(page.locator(".left-panel")).toHaveCount(0)
+
+        await page.locator("body").press("ControlOrMeta+Shift+F")
+        const input = page.locator(".search-container input.search-query")
+        await expect(input).toBeFocused()
+
+        await input.press("Escape")
+        await expect(page.locator(".left-panel")).toHaveCount(0)
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+    })
+
+    test("keeps the sidebar visible on Escape after switching away from library search", async ({ page }) => {
+        await page.locator(".status .status-block.sidebar").click()
+        await expect(page.locator(".left-panel")).toHaveCount(0)
+
+        await page.locator("body").press("ControlOrMeta+Shift+F")
+        await expect(page.locator(".search-container input.search-query")).toBeFocused()
+
+        await page.getByRole("button", { name: "Buffers" }).click()
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+
+        await page.getByRole("button", { name: "Search" }).click()
+        const input = page.locator(".search-container input.search-query")
+        await expect(input).toBeFocused()
+
+        await input.press("Escape")
+        await expect(page.locator(".left-panel")).toBeVisible()
+        await expect(page.locator(".buffer-tree")).toBeVisible()
+        await expect(page.getByRole("button", { name: "Buffers" })).toHaveClass(/selected/)
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+    })
+
     test("shows indentation guides when the sidebar is hovered", async ({ page }) => {
         await page.locator(".search-container input.search-query").fill("needle")
 

--- a/tests/playwright/sidebar-buffer-tree.spec.js
+++ b/tests/playwright/sidebar-buffer-tree.spec.js
@@ -147,6 +147,16 @@ test.describe("sidebar buffer tree", () => {
         await expect(folderB).toHaveAttribute("aria-expanded", "false")
     })
 
+    test("focuses the editor when Escape is pressed in the tree", async ({ page }) => {
+        const tree = page.locator(".buffer-tree")
+        await tree.focus()
+        await expect(tree).toBeFocused()
+
+        await tree.press("Escape")
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(tree).not.toBeFocused()
+    })
+
     test("status bar sidebar button toggles left panel", async ({ page }) => {
         await expect(page.locator(".left-panel")).toBeVisible()
 

--- a/tests/playwright/sidebar-buffer-tree.spec.js
+++ b/tests/playwright/sidebar-buffer-tree.spec.js
@@ -11,7 +11,7 @@ function createBufferContent(name, content = "") {
 function installLibraryState() {
     const settings = {
         showLeftPanel: true,
-        leftPanelWidth: 220,
+        leftPanelWidth: 250,
         bufferTreeOpenFolders: ["folder-a", "missing-folder"],
     }
     const notes = {

--- a/tests/playwright/sidebar-buffer-tree.spec.js
+++ b/tests/playwright/sidebar-buffer-tree.spec.js
@@ -210,17 +210,18 @@ test.describe("sidebar buffer tree", () => {
         const before = await leftPanel.boundingBox()
         expect(before).not.toBeNull()
 
+        const dragDelta = 120
         const startX = before.x + before.width - 1
         const y = before.y + 20
         await page.mouse.move(startX, y)
         await page.mouse.down()
-        await page.mouse.move(startX + 120, y)
+        await page.mouse.move(startX + dragDelta, y)
         await page.mouse.up()
 
         await expect.poll(async () => {
             const settings = JSON.parse(await page.evaluate(() => localStorage.getItem("settings") || "{}"))
             return settings.leftPanelWidth
-        }).toBe(340)
+        }).toBe(Math.round(before.width + dragDelta))
 
         const after = await leftPanel.boundingBox()
         expect(after.width).toBeGreaterThan(before.width + 100)

--- a/tests/playwright/sidebar-buffer-tree.spec.js
+++ b/tests/playwright/sidebar-buffer-tree.spec.js
@@ -23,6 +23,10 @@ function installLibraryState() {
     return { settings, notes }
 }
 
+function modifierKey() {
+    return process.platform === "darwin" ? "Meta" : "Control"
+}
+
 test.describe("sidebar buffer tree", () => {
     test.beforeEach(async ({ page }) => {
         const state = installLibraryState()
@@ -101,6 +105,48 @@ test.describe("sidebar buffer tree", () => {
         }).toContain("Deep content")
     })
 
+    test("supports keyboard navigation", async ({ page }) => {
+        const tree = page.locator(".buffer-tree")
+        await tree.focus()
+        await expect(tree).toBeFocused()
+
+        const folderA = page.locator(".buffer-tree .folder", { hasText: "folder-a" })
+        const folderB = page.locator(".buffer-tree .folder", { hasText: "folder-b" })
+        const deepNote = page.locator(".buffer-tree .buffer", { hasText: "Deep Note" })
+
+        for (let i = 0; i < 10; i++) {
+            await tree.press("ArrowUp")
+        }
+        await expect(folderA).toHaveClass(/selected/)
+        await expect(folderA).toHaveCSS("outline-style", "solid")
+
+        await page.locator(".cm-editor").click()
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
+        await expect(folderA).toHaveCSS("outline-style", "none")
+        await tree.focus()
+
+        await tree.press("ArrowDown")
+        await expect(folderB).toHaveClass(/selected/)
+
+        await tree.press("ArrowRight")
+        await expect(deepNote).toBeVisible()
+        await expect(folderB).toHaveAttribute("aria-expanded", "true")
+
+        await tree.press("ArrowDown")
+        await expect(deepNote).toHaveClass(/selected/)
+
+        await tree.press("Enter")
+        await expect(page.locator(".status .note")).toContainText("Deep Note")
+        await expect(page.locator(".buffer-tree .buffer.active", { hasText: "Deep Note" })).toBeVisible()
+
+        await tree.press("ArrowUp")
+        await expect(folderB).toHaveClass(/selected/)
+
+        await tree.press("ArrowLeft")
+        await expect(deepNote).toHaveCount(0)
+        await expect(folderB).toHaveAttribute("aria-expanded", "false")
+    })
+
     test("status bar sidebar button toggles left panel", async ({ page }) => {
         await expect(page.locator(".left-panel")).toBeVisible()
 
@@ -131,6 +177,21 @@ test.describe("sidebar buffer tree", () => {
 
         await page.evaluate(() => window._heynote_editor.executeCommand("toggleLeftPanel"))
         await expect(page.locator(".left-panel")).toBeVisible()
+    })
+
+    test("openBufferExplorer shortcut opens and toggles focus for the buffer tree", async ({ page }) => {
+        await page.evaluate(() => window._heynote_editor.executeCommand("toggleLeftPanel"))
+        await expect(page.locator(".left-panel")).toHaveCount(0)
+
+        await page.locator(".cm-editor").click()
+        await page.keyboard.press(`${modifierKey()}+Shift+E`)
+
+        const tree = page.locator(".buffer-tree")
+        await expect(page.locator(".left-panel")).toBeVisible()
+        await expect(tree).toBeFocused()
+
+        await page.keyboard.press(`${modifierKey()}+Shift+E`)
+        await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/)
     })
 
     test("resizes panel and persists width on mouseup", async ({ page }) => {

--- a/tests/playwright/sidebar-buffer-tree.spec.js
+++ b/tests/playwright/sidebar-buffer-tree.spec.js
@@ -64,6 +64,32 @@ test.describe("sidebar buffer tree", () => {
         await expect(page.locator(".buffer-tree .buffer", { hasText: "Nested Note" })).toHaveCount(0)
     })
 
+    test("shows indentation guide lines when the sidebar is hovered", async ({ page }) => {
+        const nestedBufferGuide = page
+            .locator(".buffer-tree .buffer", { hasText: "Nested Note" })
+            .locator(".indent-guide")
+            .first()
+
+        await expect(nestedBufferGuide).toHaveCount(1)
+
+        await page.mouse.move(500, 200)
+        await expect.poll(async () => {
+            return await nestedBufferGuide.evaluate((element) => window.getComputedStyle(element).opacity)
+        }).toBe("0")
+
+        await page.locator(".left-panel").hover()
+        await expect.poll(async () => {
+            return await nestedBufferGuide.evaluate((element) => window.getComputedStyle(element).opacity)
+        }).toBe("1")
+
+        await page.evaluate(() => window._heynote_buffer_tree.onCreateFolderRequested(null, "folder-a"))
+        const newFolderGuide = page.locator(".buffer-tree .show-indent-guides .indent-guide").first()
+        await expect(newFolderGuide).toHaveCount(1)
+        await expect.poll(async () => {
+            return await newFolderGuide.evaluate((element) => window.getComputedStyle(element).opacity)
+        }).toBe("1")
+    })
+
     test("opens selected buffer from tree", async ({ page }) => {
         await page.locator(".buffer-tree .folder", { hasText: "folder-b" }).click()
         await page.locator(".buffer-tree .buffer", { hasText: "Deep Note" }).click()

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -6,6 +6,7 @@ import {
     WINDOW_CLOSE_EVENT,
     LIBRARY_SEARCH_CANCEL,
     LIBRARY_SEARCH_DONE,
+    LIBRARY_SEARCH_ERROR,
     LIBRARY_SEARCH_MATCH,
     LIBRARY_SEARCH_START,
 } from "@/src/common/constants";
@@ -157,6 +158,17 @@ function getNoteMetadata(content) {
 
 function escapeRegExp(text) {
     return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function createLibrarySearchPattern(options, flags) {
+    const query = options?.query || ""
+    if (options.regexp) {
+        return new RegExp(query, flags)
+    }
+    if (options.wholeWord) {
+        return new RegExp(`\\b${escapeRegExp(query)}\\b`, flags)
+    }
+    return new RegExp(escapeRegExp(query), flags)
 }
 
 // Migrate single buffer (Heynote pre 2.0) in localStorage to notes library
@@ -389,9 +401,16 @@ function searchLocalLibrary(options) {
         return
     }
     const flags = options.caseSensitive ? "g" : "gi"
-    const pattern = options.wholeWord
-        ? new RegExp(`\\b${escapeRegExp(query)}\\b`, flags)
-        : new RegExp(escapeRegExp(query), flags)
+    let pattern
+    try {
+        pattern = createLibrarySearchPattern(options, flags)
+    } catch (error) {
+        ipcRenderer.send(LIBRARY_SEARCH_ERROR, {
+            searchId: options.searchId,
+            message: `Invalid regular expression: ${error.message}`,
+        })
+        return
+    }
     for (let [key, content] of Object.entries(localStorage)) {
         if (!key.startsWith(NOTE_KEY_PREFIX)) {
             continue
@@ -408,6 +427,9 @@ function searchLocalLibrary(options) {
                     end: match.index + match[0].length,
                     text: match[0],
                 })
+                if (match[0].length === 0) {
+                    pattern.lastIndex++
+                }
                 match = pattern.exec(line)
             }
             if (submatches.length === 0) {

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -1,4 +1,14 @@
-import { SETTINGS_CHANGE_EVENT, OPEN_SETTINGS_EVENT, SAVE_TABS_STATE, LOAD_TABS_STATE, WINDOW_CLOSE_EVENT } from "@/src/common/constants";
+import {
+    SETTINGS_CHANGE_EVENT,
+    OPEN_SETTINGS_EVENT,
+    SAVE_TABS_STATE,
+    LOAD_TABS_STATE,
+    WINDOW_CLOSE_EVENT,
+    LIBRARY_SEARCH_CANCEL,
+    LIBRARY_SEARCH_DONE,
+    LIBRARY_SEARCH_MATCH,
+    LIBRARY_SEARCH_START,
+} from "@/src/common/constants";
 import { NoteFormat } from "../src/common/note-format";
 
 const NOTE_KEY_PREFIX = "heynote-library__"
@@ -142,6 +152,10 @@ function getNoteMetadata(content) {
     } catch (e) {
         return {}
     }
+}
+
+function escapeRegExp(text) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 // Migrate single buffer (Heynote pre 2.0) in localStorage to notes library
@@ -302,6 +316,11 @@ const Heynote = {
                         return JSON.parse(tabsState)
                     }
                     return undefined
+                case LIBRARY_SEARCH_START:
+                    searchLocalLibrary(args[0])
+                    return { ok: true }
+                case LIBRARY_SEARCH_CANCEL:
+                    return { ok: true }
             }
         }
     },
@@ -360,6 +379,50 @@ const Heynote = {
     async getSystemLocale() {
         return navigator.language
     },
+}
+
+function searchLocalLibrary(options) {
+    const query = options?.query || ""
+    if (query.length <= 2) {
+        ipcRenderer.send(LIBRARY_SEARCH_DONE, { searchId: options?.searchId })
+        return
+    }
+    const flags = options.caseSensitive ? "g" : "gi"
+    const pattern = options.wholeWord
+        ? new RegExp(`\\b${escapeRegExp(query)}\\b`, flags)
+        : new RegExp(escapeRegExp(query), flags)
+    for (let [key, content] of Object.entries(localStorage)) {
+        if (!key.startsWith(NOTE_KEY_PREFIX)) {
+            continue
+        }
+        const buffer = key.slice(NOTE_KEY_PREFIX.length)
+        const lines = content.split(/\r?\n/)
+        lines.forEach((line, index) => {
+            const submatches = []
+            pattern.lastIndex = 0
+            let match = pattern.exec(line)
+            while (match) {
+                submatches.push({
+                    start: match.index,
+                    end: match.index + match[0].length,
+                    text: match[0],
+                })
+                match = pattern.exec(line)
+            }
+            if (submatches.length === 0) {
+                return
+            }
+            ipcRenderer.send(LIBRARY_SEARCH_MATCH, {
+                searchId: options.searchId,
+                type: "match",
+                buffer,
+                line,
+                lineNumber: index + 1,
+                submatches,
+            })
+        })
+    }
+    ipcRenderer.send(LIBRARY_SEARCH_DONE, { searchId: options.searchId })
 }
 
 window.addEventListener("beforeunload", () => ipcRenderer.send(WINDOW_CLOSE_EVENT))

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -106,6 +106,11 @@ let initialSettings = {
     showTabs: true,
     showTabsInFullscreen: true,
     cursorBlinkRate: 1000,
+    librarySearchSettings: {
+        caseSensitive: false,
+        wholeWord: false,
+        regexp: false,
+    },
 }
 if (settingsData !== null) {
     initialSettings = Object.assign(initialSettings, JSON.parse(settingsData))

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -9,6 +9,7 @@ import {
     LIBRARY_SEARCH_MATCH,
     LIBRARY_SEARCH_START,
 } from "@/src/common/constants";
+import { normalizeLibrarySearchMatch } from "@/src/common/library-search-match";
 import { NoteFormat } from "../src/common/note-format";
 
 const NOTE_KEY_PREFIX = "heynote-library__"
@@ -412,13 +413,19 @@ function searchLocalLibrary(options) {
             if (submatches.length === 0) {
                 return
             }
+            const normalizedMatch = normalizeLibrarySearchMatch({
+                line,
+                lineNumber: index + 1,
+                submatches,
+            })
+            if (!normalizedMatch) {
+                return
+            }
             ipcRenderer.send(LIBRARY_SEARCH_MATCH, {
                 searchId: options.searchId,
                 type: "match",
                 buffer,
-                line,
-                lineNumber: index + 1,
-                submatches,
+                ...normalizedMatch,
             })
         })
     }


### PR DESCRIPTION
This PR adds global library search to the sidebar.

- Desktop search is backed by ripgrep and streams JSON match events through IPC. The web app uses a localStorage-backed search implementation with the same event shape. 
- Both the buffer explorer and global search panel can now have focus, and then the arrow keys can be used to navigate the panel. The PR therefore implements global key handling for app-level commands when focus is outside the editor.
- Adds shortcuts for opening library search, opening buffer explorer, and toggling the sidebar.
- Adds sidebar indentation guide lines

<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/5d7e3feb-ccdc-4bb5-8686-cbaa022c31be" />
