### PR TITLE
Add color preview

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ For performance reasons it's recommended to use this feature if the Scratch buff
 - Persist the search query between different buffers, and between restarts
 - Add a setting for automatically installing new updates (on by default)
 - Add version and client id headers when fetching currency exchange rates
+- Add inline color preview for hex / hsl / rgb values for supported languages (CSS, HTML, JS/TS, Vue, TSX)
 
 
 ## 2.8.2

--- a/electron/config.js
+++ b/electron/config.js
@@ -75,6 +75,7 @@ const schema = {
             "defaultBlockLanguageAutoDetect": {type: "boolean"},
             "spellcheckEnabled": {type: "boolean", default:false},
             "showWhitespace": {type:"boolean", default:false},
+            "colorPreviewEnabled": {type: "boolean", default: true},
             "cursorBlinkRate": {type: "integer", default: 1000},
             "drawSettings": {
                 type: "object",
@@ -175,6 +176,7 @@ const defaults = {
         },
         spellcheckEnabled: false,
         showWhitespace: false,
+        colorPreviewEnabled: true,
         cursorBlinkRate: 1000,
     },
     theme: "system",

--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -42,6 +42,7 @@
                 showLineNumberGutter: this.initialSettings.showLineNumberGutter,
                 showFoldGutter: this.initialSettings.showFoldGutter,
                 showWhitespace: this.initialSettings.showWhitespace,
+                colorPreviewEnabled: this.initialSettings.colorPreviewEnabled ?? true,
                 showTabs: this.initialSettings.showTabs,
                 showTabsInFullscreen: this.initialSettings.showTabsInFullscreen,
                 showLeftPanel: this.initialSettings.showLeftPanel ?? true,
@@ -124,6 +125,7 @@
                     showLineNumberGutter: this.showLineNumberGutter,
                     showFoldGutter: this.showFoldGutter,
                     showWhitespace: this.showWhitespace,
+                    colorPreviewEnabled: this.colorPreviewEnabled,
                     showTabs: this.showTabs,
                     showTabsInFullscreen: this.showTabsInFullscreen,
                     showLeftPanel: this.showLeftPanel,
@@ -359,7 +361,7 @@
                         </div>
                         <div class="row">
                             <div class="entry">
-                                <h2>Gutters & Whitespace</h2>
+                                <h2>Editor Display</h2>
                                 <label>
                                     <input 
                                         type="checkbox" 
@@ -385,6 +387,15 @@
                                         @change="updateSettings"
                                     />
                                     Show white-space
+                                </label>
+
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        v-model="colorPreviewEnabled"
+                                        @change="updateSettings"
+                                    />
+                                    Show color previews (CSS, HTML, JavaScript, TypeScript, Vue, TSX)
                                 </label>
                             </div>
                         </div>

--- a/src/editor/color-preview.js
+++ b/src/editor/color-preview.js
@@ -1,0 +1,91 @@
+import { RangeSetBuilder } from "@codemirror/state"
+import { Decoration, ViewPlugin, WidgetType } from "@codemirror/view"
+
+
+const colorStartBoundary = String.raw`(^|[^\w#])` // Before the color must be start of text, or not \w / #.
+const colorEndBoundary = String.raw`(?!\w)` // After the color must not be \w.
+const hexColor = String.raw`#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})`
+const rgbColor = String.raw`rgba?\([^()\n]*\)`
+const hslColor = String.raw`hsla?\([^()\n]*\)`
+
+const colorCandidateRegex = new RegExp(
+    `${colorStartBoundary}(${[
+        hexColor,
+        rgbColor,
+        hslColor,
+    ].join("|")})${colorEndBoundary}`,
+    "gi",
+)
+
+function isValidCssColor(color) {
+    if (window.CSS?.supports?.("color", color)) {
+        return true
+    }
+
+    // Check whether the browser can parse this as a CSS color.
+    const testElement = document.createElement("span")
+    testElement.style.color = color
+    return testElement.style.color !== ""
+}
+
+class ColorPreviewWidget extends WidgetType {
+    constructor(color) {
+        super()
+        this.color = color
+    }
+
+    eq(other) {
+        return other.color === this.color
+    }
+
+    toDOM() {
+        const swatch = document.createElement("span")
+        swatch.className = "heynote-color-preview"
+        swatch.style.backgroundColor = this.color
+        swatch.title = this.color
+        swatch.setAttribute("aria-hidden", "true")
+        return swatch
+    }
+
+    ignoreEvent() {
+        return true
+    }
+}
+
+function buildColorPreviewDecorations(view) {
+    const builder = new RangeSetBuilder()
+
+    for (const { from, to } of view.visibleRanges) {
+        const text = view.state.sliceDoc(from, to)
+        let match
+        colorCandidateRegex.lastIndex = 0
+        while ((match = colorCandidateRegex.exec(text)) !== null) {
+            const color = match[2]
+            if (!isValidCssColor(color)) {
+                continue
+            }
+
+            const pos = from + match.index + match[1].length
+            builder.add(pos, pos, Decoration.widget({
+                widget: new ColorPreviewWidget(color),
+                side: -1,
+            }))
+        }
+    }
+
+    return builder.finish()
+}
+
+export const colorPreviewExtension = ViewPlugin.fromClass(class {
+    constructor(view) {
+        this.decorations = buildColorPreviewDecorations(view)
+    }
+
+    update(update) {
+        if (update.docChanged || update.viewportChanged) {
+            this.decorations = buildColorPreviewDecorations(update.view)
+        }
+    }
+}, {
+    decorations: instance => instance.decorations,
+})

--- a/src/editor/color-preview.js
+++ b/src/editor/color-preview.js
@@ -1,6 +1,8 @@
 import { RangeSetBuilder } from "@codemirror/state"
 import { Decoration, ViewPlugin, WidgetType } from "@codemirror/view"
 
+import { getNoteBlockFromPos } from "./block/block"
+
 
 const colorStartBoundary = String.raw`(^|[^\w#])` // Before the color must be start of text, or not \w / #.
 const colorEndBoundary = String.raw`(?!\w)` // After the color must not be \w.
@@ -17,6 +19,8 @@ const colorCandidateRegex = new RegExp(
     "gi",
 )
 
+const previewLanguages = new Set(["css", "html", "javascript", "typescript", "vue", "tsx"])
+
 function isValidCssColor(color) {
     if (window.CSS?.supports?.("color", color)) {
         return true
@@ -26,6 +30,11 @@ function isValidCssColor(color) {
     const testElement = document.createElement("span")
     testElement.style.color = color
     return testElement.style.color !== ""
+}
+
+function shouldPreviewColor(state, pos) {
+    const block = getNoteBlockFromPos(state, pos)
+    return previewLanguages.has(block?.language?.name)
 }
 
 class ColorPreviewWidget extends WidgetType {
@@ -66,6 +75,10 @@ function buildColorPreviewDecorations(view) {
             }
 
             const pos = from + match.index + match[1].length
+            if (!shouldPreviewColor(view.state, pos)) {
+                continue
+            }
+
             builder.add(pos, pos, Decoration.widget({
                 widget: new ColorPreviewWidget(color),
                 side: -1,

--- a/src/editor/color-preview.js
+++ b/src/editor/color-preview.js
@@ -81,7 +81,7 @@ function buildColorPreviewDecorations(view) {
 
             builder.add(pos, pos, Decoration.widget({
                 widget: new ColorPreviewWidget(color),
-                side: -1,
+                side: 1,
             }))
         }
     }

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -64,6 +64,7 @@ export class HeynoteEditor {
         keyBindings,
         spellcheckEnabled=false,
         showWhitespace=false,
+        colorPreviewEnabled=true,
         cursorBlinkRate=1000,
     }) {
         this.element = element
@@ -77,6 +78,7 @@ export class HeynoteEditor {
         this.closeBracketsCompartment = new Compartment
         this.indentUnitCompartment = new Compartment
         this.highlightWhitespaceCompartment = new Compartment
+        this.colorPreviewCompartment = new Compartment
         this.cursorBlinkCompartment = new Compartment
         this.deselectOnCopy = keymap === "emacs"
         this.emacsMetaKey = emacsMetaKey
@@ -135,7 +137,7 @@ export class HeynoteEditor {
                 Prec.highest(cmKeymap.of(markdownKeymap)),
 
                 links,
-                colorPreviewExtension,
+                this.colorPreviewCompartment.of(colorPreviewEnabled ? colorPreviewExtension : []),
 
                 this.spellcheckCompartment.of(spellcheckConfig(this.spellcheckEnabled)),
                 this.highlightWhitespaceCompartment.of(showWhitespace ? highlightWhitespace() : [])
@@ -353,6 +355,12 @@ export class HeynoteEditor {
     setShowWhitespace(enabled) {
         this.view.dispatch({
             effects: this.highlightWhitespaceCompartment.reconfigure(enabled ? highlightWhitespace() : []),
+        })
+    }
+
+    setColorPreviewEnabled(enabled) {
+        this.view.dispatch({
+            effects: this.colorPreviewCompartment.reconfigure(enabled ? colorPreviewExtension : []),
         })
     }
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -24,6 +24,7 @@ import { autoSaveContent } from "./save.js"
 import { imageExtension } from "./image/image.js"
 import { todoCheckboxPlugin} from "./todo-checkbox.ts"
 import { links } from "./links.js"
+import { colorPreviewExtension } from "./color-preview.js"
 import { indentation } from "./indentation.js"
 import { HEYNOTE_COMMANDS } from "./commands.js";
 import { NoteFormat } from "../common/note-format.js"
@@ -134,6 +135,7 @@ export class HeynoteEditor {
                 Prec.highest(cmKeymap.of(markdownKeymap)),
 
                 links,
+                colorPreviewExtension,
 
                 this.spellcheckCompartment.of(spellcheckConfig(this.spellcheckEnabled)),
                 this.highlightWhitespaceCompartment.of(showWhitespace ? highlightWhitespace() : [])

--- a/src/editor/theme/base.js
+++ b/src/editor/theme/base.js
@@ -141,6 +141,16 @@ export const heynoteBase = EditorView.theme({
     '.heynote-link': {
         textDecoration: "underline",
     },
+    '.heynote-color-preview': {
+        display: "inline-block",
+        width: "0.8em",
+        height: "0.8em",
+        marginRight: "0.3em",
+        border: "1px solid rgba(128,128,128,0.65)",
+        borderRadius: "2px",
+        boxSizing: "border-box",
+        verticalAlign: "-0.08em",
+    },
 
     ".cm-searchMatch": { backgroundColor: "#ffff00" },
     ".cm-searchMatch-selected": {

--- a/src/stores/editor-cache.js
+++ b/src/stores/editor-cache.js
@@ -47,6 +47,7 @@ export const useEditorCacheStore = defineStore("editorCache", {
                     keyBindings: settingsStore.settings.keyBindings,
                     spellcheckEnabled: settingsStore.settings.spellcheckEnabled,
                     showWhitespace: settingsStore.settings.showWhitespace,
+                    colorPreviewEnabled: settingsStore.settings.colorPreviewEnabled ?? true,
                     cursorBlinkRate: settingsStore.settings.cursorBlinkRate,
                     focus: options.focus !== false,
                 })
@@ -187,6 +188,9 @@ export const useEditorCacheStore = defineStore("editorCache", {
                                 break
                             case "showWhitespace":
                                 editor.setShowWhitespace(newSettings.showWhitespace)
+                                break;
+                            case "colorPreviewEnabled":
+                                editor.setColorPreviewEnabled(newSettings.colorPreviewEnabled ?? true)
                                 break;
                             case "cursorBlinkRate":
                                 editor.setCursorBlinkRate(newSettings.cursorBlinkRate)

--- a/tests/playwright/color-preview.spec.js
+++ b/tests/playwright/color-preview.spec.js
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+import { HeynotePage } from "./test-utils.js";
+
+let heynotePage
+
+test.beforeEach(async ({ page }) => {
+    heynotePage = new HeynotePage(page)
+    await heynotePage.goto()
+});
+
+test("color previews are shown for valid CSS colors in supported languages", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞css
+.button {
+    color: #123456;
+    background: rgba(255, 0, 128, 0.5);
+    border-color: not-a-color;
+}
+∞∞∞text
+Plain text #abcdef
+∞∞∞python
+color = "#fedcba"
+`)
+
+    const previews = page.locator(".heynote-color-preview")
+    await expect(previews).toHaveCount(2)
+    await expect(previews.nth(0)).toHaveAttribute("title", "#123456")
+    await expect(previews.nth(1)).toHaveAttribute("title", "rgba(255, 0, 128, 0.5)")
+})
+
+test("color previews can be disabled and re-enabled from settings", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞css
+.button {
+    color: #123456;
+}
+`)
+
+    await expect(page.locator(".heynote-color-preview")).toHaveCount(1)
+
+    await page.locator("css=.status-block.settings").click()
+    await page.locator("css=li.tab-appearance").click()
+    await page.getByLabel("Show color previews").click()
+
+    await expect(page.locator(".heynote-color-preview")).toHaveCount(0)
+    expect((await heynotePage.getStoredSettings()).colorPreviewEnabled).toBe(false)
+
+    await page.getByLabel("Show color previews").click()
+
+    await expect(page.locator(".heynote-color-preview")).toHaveCount(1)
+    expect((await heynotePage.getStoredSettings()).colorPreviewEnabled).toBe(true)
+})
+
+test("color preview is rendered to the right of the cursor at the color start", async ({ page }) => {
+    await heynotePage.setContent(`
+∞∞∞css
+.button {
+    color: #123456;
+}
+`)
+
+    const colorStart = await page.evaluate(() => window._heynote_editor.view.state.doc.toString().indexOf("#123456"))
+    await heynotePage.setCursorPosition(colorStart)
+    await page.evaluate(() => window._heynote_editor.view.focus())
+
+    await expect(page.locator(".heynote-color-preview")).toHaveCount(1)
+    await expect(page.locator(".cm-cursor-primary")).toBeVisible()
+
+    const positions = await page.evaluate(() => {
+        const cursor = document.querySelector(".cm-cursor-primary").getBoundingClientRect()
+        const preview = document.querySelector(".heynote-color-preview").getBoundingClientRect()
+        return {
+            cursorLeft: cursor.left,
+            previewLeft: preview.left,
+        }
+    })
+
+    expect(positions.previewLeft).toBeGreaterThanOrEqual(positions.cursorLeft)
+})

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -119,6 +119,7 @@ let initialSettings = {
     showTabs: true,
     showTabsInFullscreen: true,
     leftPanelWidth: DEFAULT_LEFT_PANEL_WIDTH,
+    colorPreviewEnabled: true,
     cursorBlinkRate: 1000,
     librarySearchSettings: {
         caseSensitive: false,


### PR DESCRIPTION
This PR implements #421 .

- adds inline color preview for hex / hsl / rgb values
  - first filtered with regex, then validated using CSS parsing
  - named colors are intentionally excluded
  - applied to CSS, HTML, JS/TS, Vue, TSX
- adds a related setting (default: on)
  - instead of adding a new category, renamed an existing one to keep things simple