### PR TITLE
Fix restoring windows from disconnected displays

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -15,6 +15,7 @@ import CONFIG from "../config"
 import { isDev, isLinux, isMac, isWindows } from '../detect-platform';
 import { initializeAutoUpdate, checkForUpdates, updateAutoInstallUpdates } from './auto-update';
 import { fixElectronCors } from './cors';
+import { ensureWindowBoundsVisible } from './window-bounds';
 import { 
     FileLibrary, 
     setupFileLibraryEventHandlers, 
@@ -88,6 +89,38 @@ export function quit() {
     app.quit()
 }
 
+function getVisibleWindowBounds(bounds: { width: number, height: number, x?: number, y?: number }) {
+    return ensureWindowBoundsVisible(bounds, screen.getAllDisplays())
+}
+
+function ensureWindowVisible() {
+    if (!win) {
+        return
+    }
+
+    const bounds = win.getBounds()
+    const visibleBounds = getVisibleWindowBounds(bounds)
+    if (
+        visibleBounds.x !== bounds.x ||
+        visibleBounds.y !== bounds.y ||
+        visibleBounds.width !== bounds.width ||
+        visibleBounds.height !== bounds.height
+    ) {
+        if (visibleBounds.x !== undefined && visibleBounds.y !== undefined) {
+            if (win.isFullScreen()) {
+                return
+            }
+
+            win.setBounds({
+                x: visibleBounds.x,
+                y: visibleBounds.y,
+                width: visibleBounds.width,
+                height: visibleBounds.height,
+            })
+        }
+    }
+}
+
 function showWindow() {
     if (!win) {
         return
@@ -96,6 +129,7 @@ function showWindow() {
     if (win.isMinimized()) {
         win.restore()
     }
+    ensureWindowVisible()
     if (!wasVisible) {
         // hide()+show() forces the window to the top of the window stack on
         // Linux WMs that don't raise windows on a bare show() call
@@ -139,29 +173,7 @@ async function createWindow() {
     let currentWindowIsMaximized = windowWasMaximized
     let currentWindowIsFullScreen = windowWasFullScreen
 
-    // windowBounds.x and windowBounds.y will be undefined when config file is missing, e.g. first time run
-    if (windowBounds.x !== undefined && windowBounds.y !== undefined) {
-        // check if window is outside of screen, or too large
-        const display = screen.getDisplayMatching({
-            x: windowBounds.x,
-            y: windowBounds.y,
-            width: windowBounds.width,
-            height: windowBounds.height,
-        })
-        //console.log("bounds:", display.bounds, "workArea:", display.workArea)
-        const area = display.workArea
-        if (windowBounds.width > area.width) {
-            windowBounds.width = area.width
-        }
-        if (windowBounds.height > area.height) {
-            windowBounds.height = area.height
-        }
-        if (windowBounds.x + windowBounds.width > area.x + area.width || windowBounds.y + windowBounds.height > area.y + area.height) {
-            // window is outside of screen, reset position
-            windowBounds.x = undefined
-            windowBounds.y = undefined
-        }
-    }
+    windowBounds = getVisibleWindowBounds(windowBounds)
 
     const pngSystems: NodeJS.Platform[] = ["linux", "freebsd", "openbsd", "netbsd"]
     const icon = join(
@@ -275,6 +287,7 @@ async function createWindow() {
     // without this, there are cases when Cmd-Tabbing to Heynote won't show the window
     app.on("did-become-active", (event) => {
         if (!win.isVisible()) {
+            ensureWindowVisible()
             win.show()
         }
     })
@@ -484,6 +497,11 @@ registerProtocolBeforeAppReady()
 app.whenReady().then(createWindow).then(async () => {
     initFileLibrary(win).then(() => {
         setupFileLibraryEventHandlers()
+    })
+    screen.on("display-removed", () => {
+        if (win?.isVisible()) {
+            ensureWindowVisible()
+        }
     })
     initializeAutoUpdate(win)
     registerGlobalHotkey()

--- a/electron/main/window-bounds.ts
+++ b/electron/main/window-bounds.ts
@@ -1,0 +1,75 @@
+export type WindowBounds = {
+    width: number
+    height: number
+    x?: number
+    y?: number
+}
+
+export type RectangleBounds = {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+export type DisplayBounds = {
+    bounds: RectangleBounds
+    workArea: RectangleBounds
+}
+
+function hasPosition(bounds: WindowBounds): bounds is Required<WindowBounds> {
+    return bounds.x !== undefined && bounds.y !== undefined
+}
+
+function intersects(a: Required<WindowBounds>, b: RectangleBounds) {
+    const left = Math.max(a.x, b.x)
+    const right = Math.min(a.x + a.width, b.x + b.width)
+    const top = Math.max(a.y, b.y)
+    const bottom = Math.min(a.y + a.height, b.y + b.height)
+
+    return right > left && bottom > top
+}
+
+function distanceFromPointToRect(point: { x: number, y: number }, rect: RectangleBounds) {
+    const dx = Math.max(rect.x - point.x, 0, point.x - (rect.x + rect.width))
+    const dy = Math.max(rect.y - point.y, 0, point.y - (rect.y + rect.height))
+    return (dx * dx) + (dy * dy)
+}
+
+function getNearestDisplay(bounds: Required<WindowBounds>, displays: DisplayBounds[]) {
+    const center = {
+        x: bounds.x + (bounds.width / 2),
+        y: bounds.y + (bounds.height / 2),
+    }
+
+    return displays.reduce((nearest, display) => {
+        const nearestDistance = distanceFromPointToRect(center, nearest.bounds)
+        const displayDistance = distanceFromPointToRect(center, display.bounds)
+        return displayDistance < nearestDistance ? display : nearest
+    })
+}
+
+function clampToWorkArea(bounds: Required<WindowBounds>, workArea: RectangleBounds): Required<WindowBounds> {
+    const width = Math.min(bounds.width, workArea.width)
+    const height = Math.min(bounds.height, workArea.height)
+
+    return {
+        width,
+        height,
+        x: Math.min(Math.max(bounds.x, workArea.x), workArea.x + workArea.width - width),
+        y: Math.min(Math.max(bounds.y, workArea.y), workArea.y + workArea.height - height),
+    }
+}
+
+export function ensureWindowBoundsVisible(bounds: WindowBounds, displays: DisplayBounds[]): WindowBounds {
+    if (!hasPosition(bounds) || displays.length === 0) {
+        return bounds
+    }
+
+    if (displays.some((display) => intersects(bounds, display.bounds))) {
+        return bounds
+    }
+
+    const targetDisplay = getNearestDisplay(bounds, displays)
+    return clampToWorkArea(bounds, targetDisplay.workArea)
+}

--- a/tests/main/window-bounds.test.js
+++ b/tests/main/window-bounds.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { ensureWindowBoundsVisible } from "../../electron/main/window-bounds"
+
+const displays = [
+    {
+        bounds: { x: 0, y: 0, width: 1440, height: 900 },
+        workArea: { x: 0, y: 25, width: 1440, height: 875 },
+    },
+    {
+        bounds: { x: 1440, y: 0, width: 1920, height: 1080 },
+        workArea: { x: 1440, y: 0, width: 1920, height: 1040 },
+    },
+]
+
+describe("ensureWindowBoundsVisible", () => {
+    it("keeps bounds that are visible on an attached display", () => {
+        const bounds = { x: 1600, y: 100, width: 940, height: 720 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual(bounds)
+    })
+
+    it("moves off-screen bounds onto the nearest remaining display", () => {
+        const bounds = { x: 3600, y: 100, width: 940, height: 720 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual({
+            x: 2420,
+            y: 100,
+            width: 940,
+            height: 720,
+        })
+    })
+
+    it("keeps bounds that are only partly visible", () => {
+        const bounds = { x: -900, y: 100, width: 940, height: 720 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual(bounds)
+    })
+
+    it("keeps oversized bounds if any part of the window is visible", () => {
+        const bounds = { x: 200, y: 100, width: 2000, height: 1200 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual(bounds)
+    })
+
+    it("shrinks off-screen bounds that are larger than the target work area", () => {
+        const bounds = { x: 3600, y: 100, width: 2000, height: 1200 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual({
+            x: 1440,
+            y: 0,
+            width: 1920,
+            height: 1040,
+        })
+    })
+
+    it("leaves unpositioned bounds unchanged", () => {
+        const bounds = { width: 940, height: 720 }
+
+        expect(ensureWindowBoundsVisible(bounds, displays)).toEqual(bounds)
+    })
+})


### PR DESCRIPTION
Move Heynote back onto a connected display when its saved or current window bounds no longer intersect any available display.

This handles:
- startup with saved bounds from a disconnected screen
- visible windows after a display is removed
- hidden windows shown later through tray, hotkey, or app activation

Partially visible windows are left untouched