### PR TITLE
Fix library search for short CJK queries

### DIFF
--- a/.github/workflows/mac-e2e-tests.yml
+++ b/.github/workflows/mac-e2e-tests.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: latest
+        cache-dependency-path: false
     - name: Install dependencies
       run: npm ci
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: latest
-        cache-dependency-path: 'package-lock.json'
+        package-manager-cache: false
     - name: Install xvfb
       run: sudo apt-get install xvfb
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: latest
+        cache-dependency-path: 'package-lock.json'
     - name: Install xvfb
       run: sudo apt-get install xvfb
     - name: Install dependencies

--- a/electron/main/ripgrep.js
+++ b/electron/main/ripgrep.js
@@ -4,6 +4,7 @@ import { once } from "node:events"
 import readline from "node:readline"
 
 import { IMAGE_REGEX_RIPGREP } from "@/src/common/constants.js"
+import { isLibrarySearchQueryLongEnough } from "@/src/common/library-search-query.js"
 import { normalizeLibrarySearchMatch } from "@/src/common/library-search-match.js"
 import { parseImagesFromString } from "@/src/editor/image/image-parsing.js"
 
@@ -83,8 +84,8 @@ export function startLibrarySearch(library, options, onEvent) {
         throw Error("library.basePath not set, is library initialized?")
     }
     const query = options?.query || ""
-    if (query.length <= 2) {
-        throw Error("Search query must be longer than 2 characters")
+    if (!isLibrarySearchQueryLongEnough(query)) {
+        throw Error("Search query is too short")
     }
 
     const args = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron/asar": "^3.2.2",
         "@lezer/generator": "^1.5.1",
         "@lezer/markdown": "^1.4.2",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.61.0",
         "@replit/codemirror-lang-csharp": "^6.2.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@types/node": "^20.10.5",
@@ -2231,13 +2231,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9487,13 +9487,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9506,9 +9506,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3671,15 +3671,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5368,15 +5359,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -13618,13 +13600,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -98,5 +98,18 @@
     "pinia": "^2.1.7",
     "pinyin-pro": "^3.27.0",
     "semver": "^7.6.3"
+  },
+  "allowScripts": {
+    "electron@39.3.0": true,
+    "esbuild@0.27.2": true,
+    "esbuild@0.21.5": true,
+    "esbuild@0.25.12": true,
+    "@parcel/watcher@2.5.6": true,
+    "@vscode/ripgrep@1.17.0": true,
+    "canvas@3.2.1": true,
+    "electron-winstaller@5.4.0": true,
+    "vue-demi@0.14.10": true,
+    "fsevents@2.3.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@electron/asar": "^3.2.2",
     "@lezer/generator": "^1.5.1",
     "@lezer/markdown": "^1.4.2",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.61.0",
     "@replit/codemirror-lang-csharp": "^6.2.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@types/node": "^20.10.5",

--- a/package.json
+++ b/package.json
@@ -111,5 +111,8 @@
     "vue-demi@0.14.10": true,
     "fsevents@2.3.2": true,
     "fsevents@2.3.3": true
+  },
+  "overrides": {
+    "yauzl": "^3.3.1"
   }
 }

--- a/src/common/library-search-query.js
+++ b/src/common/library-search-query.js
@@ -1,0 +1,19 @@
+const MIN_LIBRARY_SEARCH_QUERY_BYTES = 3
+const textEncoder = typeof TextEncoder !== "undefined" ? new TextEncoder() : null
+
+function utf8ByteLength(text) {
+    if (textEncoder) {
+        return textEncoder.encode(text).length
+    }
+
+    let byteLength = 0
+    for (const codePoint of text) {
+        byteLength += encodeURIComponent(codePoint).replace(/%[A-F\d]{2}/g, "x").length
+    }
+    return byteLength
+}
+
+export function isLibrarySearchQueryLongEnough(query) {
+    const trimmedQuery = (query || "").trim()
+    return utf8ByteLength(trimmedQuery) >= MIN_LIBRARY_SEARCH_QUERY_BYTES
+}

--- a/src/components/library-search/LibrarySearch.vue
+++ b/src/components/library-search/LibrarySearch.vue
@@ -4,6 +4,7 @@
     import { useSearchStore } from '@/src/stores/search-store';
     import { useHeynoteStore } from "@/src/stores/heynote-store";
     import { useSettingsStore } from "@/src/stores/settings-store.js";
+    import { isLibrarySearchQueryLongEnough } from "@/src/common/library-search-query.js";
     import InputToggle from '@/src/editor/search/InputToggle.vue';
     import SearchResult from "./SearchResult.vue";
 
@@ -66,7 +67,7 @@
             ]),
 
             hasSearchQuery() {
-                return this.query.trim().length > 2
+                return isLibrarySearchQueryLongEnough(this.query)
             },
 
             resultCount() {

--- a/src/stores/search-store.js
+++ b/src/stores/search-store.js
@@ -6,6 +6,7 @@ import {
     LIBRARY_SEARCH_MATCH,
     LIBRARY_SEARCH_START,
 } from "@/src/common/constants"
+import { isLibrarySearchQueryLongEnough } from "@/src/common/library-search-query.js"
 
 const defaultLibrarySearchSettings = {
     caseSensitive: false,
@@ -146,7 +147,7 @@ export const useSearchStore = defineStore("search", {
             this.selectedResultRow = null
             this.error = null
 
-            if (query.trim().length <= 2) {
+            if (!isLibrarySearchQueryLongEnough(query)) {
                 this.searching = false
                 Promise.resolve(window.heynote.mainProcess.invoke(LIBRARY_SEARCH_CANCEL)).catch(() => {})
                 return

--- a/tests/main/ripgrep.test.js
+++ b/tests/main/ripgrep.test.js
@@ -184,6 +184,30 @@ describe("startLibrarySearch", () => {
         expect(submatch.start).toBe(line.lastIndexOf("foo"))
     })
 
+    it("allows CJK queries shorter than three JavaScript characters", async () => {
+        await fs.promises.writeFile(
+            path.join(tmpDir, "scratch.txt"),
+            "prefix 中文 match\n",
+            "utf8"
+        )
+
+        const events = await runLibrarySearch(tmpDir, {
+            searchId: 790,
+            query: "中",
+            caseSensitive: true,
+            wholeWord: false,
+        })
+        const matches = events.filter((event) => event.type === "match")
+
+        expect(matches).toHaveLength(1)
+        expect(matches[0]).toMatchObject({
+            buffer: "scratch.txt",
+            line: "prefix 中文 match",
+            lineNumber: 1,
+            submatches: [{ start: 7, end: 8, text: "中" }],
+        })
+    })
+
     it("ignores Heynote metadata, block delimiters, and tags", async () => {
         const tag = "<∞img;id=1;file=https://example.com/needle.png;w=10;h=10∞>"
         const content = [

--- a/tests/playwright/library-search.spec.js
+++ b/tests/playwright/library-search.spec.js
@@ -18,6 +18,7 @@ function installLibraryState() {
             "first needle match <∞img;id=search-test;file=https://example.com/needle.png;w=10;h=10∞>",
             "second needle match",
             "issue-123 is tracked",
+            "Chinese query 中文搜索",
             "short non-match",
         ].join("\n")),
         "folder-a/project.txt": createBufferContent("Project Note", [
@@ -84,6 +85,14 @@ test.describe("library search", () => {
         await expect(page.locator(".result-summary")).toContainText("2 results in 2 buffers")
         await expect(page.locator(".result-container .match strong", { hasText: "issue-123" })).toHaveCount(1)
         await expect(page.locator(".result-container .match strong", { hasText: "issue-456" })).toHaveCount(1)
+    })
+
+    test("supports CJK queries shorter than three JavaScript characters", async ({ page }) => {
+        await page.locator(".search-container input.search-query").fill("中")
+
+        await expect(page.locator(".result-summary")).toContainText("1 results in 1 buffers")
+        await expect(page.locator(".result-container .match")).toHaveCount(1)
+        await expect(page.locator(".result-container .match strong")).toHaveText("中")
     })
 
     test("persists search setting toggles and defaults them to off", async ({ page }) => {

--- a/webapp/bridge.js
+++ b/webapp/bridge.js
@@ -14,6 +14,7 @@ import {
 import { generateClientId, TEST_CLIENT_ID } from "@/src/common/client-id";
 import { CURRENCY_RATES_URL, getCurrencyFetchOptions } from "@/src/common/currency-request";
 import { normalizeLibrarySearchMatch } from "@/src/common/library-search-match";
+import { isLibrarySearchQueryLongEnough } from "@/src/common/library-search-query.js";
 import { NoteFormat } from "../src/common/note-format";
 
 const NOTE_KEY_PREFIX = "heynote-library__"
@@ -425,7 +426,7 @@ const Heynote = {
 
 function searchLocalLibrary(options) {
     const query = options?.query || ""
-    if (query.length <= 2) {
+    if (!isLibrarySearchQueryLongEnough(query)) {
         ipcRenderer.send(LIBRARY_SEARCH_DONE, { searchId: options?.searchId })
         return
     }


### PR DESCRIPTION
Library search rejected queries with a JavaScript string length of two or less before invoking ripgrep. That made common Chinese searches such as "中" or "中文" no-op, even though ripgrep can match them correctly.

Fixes #489 